### PR TITLE
chore: adopt deploy assets from backend repo

### DIFF
--- a/aws-scripts/01-docker.sh
+++ b/aws-scripts/01-docker.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> [01] Installing Docker and system packages"
+
+# Base packages
+apt-get update
+apt-get install -y \
+  ca-certificates \
+  curl \
+  gnupg \
+  jq \
+  certbot \
+  python3-certbot-nginx \
+  nginx \
+  ufw \
+  fail2ban
+
+# Docker official GPG key and repo
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# Enable Docker
+systemctl enable docker
+
+# Allow ubuntu user to use docker
+usermod -aG docker ubuntu
+
+# Configure UFW (don't enable yet — first-boot will)
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow ssh
+ufw allow http
+ufw allow https
+
+systemctl enable fail2ban
+
+echo "==> [01] Docker installed"

--- a/aws-scripts/02-artifact-keeper.sh
+++ b/aws-scripts/02-artifact-keeper.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "==> [02] Setting up Artifact Keeper (Docker Compose)"
+
+AK_DIR="/opt/artifact-keeper"
+mkdir -p "${AK_DIR}"
+
+# Copy compose file and first-boot script from packer upload
+# Debug: show what packer uploaded
+echo "==> Contents of /tmp/ak-scripts:"
+find /tmp/ak-scripts -type f 2>/dev/null || true
+ls -laR /tmp/ak-scripts/ 2>/dev/null || true
+
+# Find the source directory (packer may nest under scripts/ or upload flat)
+SRC=$(find /tmp/ak-scripts -name "docker-compose.yml" -printf '%h' -quit 2>/dev/null || true)
+if [ -z "${SRC}" ]; then
+    echo "ERROR: docker-compose.yml not found in /tmp/ak-scripts"
+    exit 1
+fi
+echo "==> Found files in: ${SRC}"
+
+cp "${SRC}/docker-compose.yml" "${AK_DIR}/docker-compose.yml"
+cp "${SRC}/first-boot.sh" "${AK_DIR}/first-boot.sh"
+cp "${SRC}/nginx-host.conf" "${AK_DIR}/nginx-host.conf"
+chmod +x "${AK_DIR}/first-boot.sh"
+
+# Create data directories
+mkdir -p /data/{postgres,meilisearch,storage,trivy-cache}
+
+# Pull images now so first boot is fast
+AK_VERSION="${ARTIFACT_KEEPER_VERSION:-latest}"
+cd "${AK_DIR}"
+
+# Write the .env with the version tag
+cat > "${AK_DIR}/.env" <<EOF
+ARTIFACT_KEEPER_VERSION=${AK_VERSION}
+# Populated by first-boot:
+DB_PASSWORD=changeme
+JWT_SECRET=changeme
+MEILI_MASTER_KEY=changeme
+EOF
+chmod 600 "${AK_DIR}/.env"
+
+docker compose pull
+
+# Systemd service for docker compose
+cat > /etc/systemd/system/artifact-keeper.service <<'EOF'
+[Unit]
+Description=Artifact Keeper (Docker Compose)
+After=docker.service artifact-keeper-first-boot.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/artifact-keeper
+ExecStart=/usr/bin/docker compose up -d --wait
+ExecStop=/usr/bin/docker compose down
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# First-boot one-shot service
+cat > /etc/systemd/system/artifact-keeper-first-boot.service <<'EOF'
+[Unit]
+Description=Artifact Keeper first-boot configuration
+After=docker.service network-online.target
+Wants=network-online.target
+Before=artifact-keeper.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/artifact-keeper/first-boot.sh
+RemainAfterExit=yes
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable artifact-keeper-first-boot
+systemctl enable artifact-keeper
+
+echo "==> [02] Artifact Keeper configured"

--- a/aws-scripts/99-cleanup.sh
+++ b/aws-scripts/99-cleanup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> [99] Cleaning up for AMI snapshot"
+
+apt-get clean
+apt-get autoremove -y
+rm -rf /var/lib/apt/lists/*
+rm -rf /tmp/*
+rm -rf /var/tmp/*
+
+journalctl --rotate
+journalctl --vacuum-time=1s
+find /var/log -type f -name "*.log" -exec truncate -s 0 {} \;
+find /var/log -type f -name "*.gz" -delete
+
+rm -f /etc/ssh/ssh_host_*
+truncate -s 0 /etc/machine-id
+
+unset HISTFILE
+rm -f /root/.bash_history
+rm -f /home/ubuntu/.bash_history
+
+echo "==> [99] Cleanup complete — ready for snapshot"

--- a/aws-scripts/docker-compose.yml
+++ b/aws-scripts/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: artifact_keeper
+      POSTGRES_USER: artifact_keeper
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - /data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U artifact_keeper -d artifact_keeper"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.12
+    restart: always
+    environment:
+      MEILI_ENV: production
+      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
+      MEILI_HTTP_ADDR: 0.0.0.0:7700
+    volumes:
+      - /data/meilisearch:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  trivy:
+    image: aquasec/trivy:latest
+    restart: always
+    command: ["server", "--listen", "0.0.0.0:8090"]
+    volumes:
+      - /data/trivy-cache:/root/.cache/trivy
+
+  backend:
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
+    restart: always
+    environment:
+      DATABASE_URL: postgresql://artifact_keeper:${DB_PASSWORD}@postgres:5432/artifact_keeper
+      BIND_ADDRESS: 0.0.0.0:8080
+      STORAGE_BACKEND: filesystem
+      STORAGE_PATH: /data/storage
+      JWT_SECRET: ${JWT_SECRET}
+      MEILISEARCH_URL: http://meilisearch:7700
+      MEILISEARCH_API_KEY: ${MEILI_MASTER_KEY}
+      TRIVY_URL: http://trivy:8090
+      RUST_LOG: info
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - /data/storage:/data/storage
+    depends_on:
+      postgres:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+
+  web:
+    image: ghcr.io/artifact-keeper/artifact-keeper-web:${ARTIFACT_KEEPER_VERSION:-latest}
+    restart: always
+    environment:
+      BACKEND_URL: http://backend:8080
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - backend

--- a/aws-scripts/first-boot.sh
+++ b/aws-scripts/first-boot.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MARKER="/opt/artifact-keeper/.first-boot-complete"
+CREDS_FILE="/opt/artifact-keeper/.credentials"
+AK_DIR="/opt/artifact-keeper"
+
+if [ -f "$MARKER" ]; then
+    echo "First boot already completed, skipping."
+    exit 0
+fi
+
+echo "==> Artifact Keeper first-boot configuration"
+
+# -------------------------------------------------------------------------
+# 1. Generate secrets
+# -------------------------------------------------------------------------
+DB_PASSWORD=$(openssl rand -hex 24)
+JWT_SECRET=$(openssl rand -hex 32)
+MEILI_KEY=$(openssl rand -hex 24)
+
+# -------------------------------------------------------------------------
+# 2. Write .env for Docker Compose
+# -------------------------------------------------------------------------
+cat > "${AK_DIR}/.env" <<EOF
+ARTIFACT_KEEPER_VERSION=$(grep ARTIFACT_KEEPER_VERSION "${AK_DIR}/.env" | cut -d= -f2)
+DB_PASSWORD=${DB_PASSWORD}
+JWT_SECRET=${JWT_SECRET}
+MEILI_MASTER_KEY=${MEILI_KEY}
+EOF
+chmod 600 "${AK_DIR}/.env"
+
+# -------------------------------------------------------------------------
+# 3. Read user-data for optional domain configuration
+# -------------------------------------------------------------------------
+DOMAIN=""
+ADMIN_EMAIL=""
+TOKEN=""
+if TOKEN=$(curl -s --max-time 2 -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null); then
+    USERDATA=$(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: ${TOKEN}" \
+        "http://169.254.169.254/latest/user-data" 2>/dev/null || true)
+    if [ -n "$USERDATA" ]; then
+        DOMAIN=$(echo "$USERDATA" | grep -oP '^DOMAIN=\K.*' || true)
+        ADMIN_EMAIL=$(echo "$USERDATA" | grep -oP '^ADMIN_EMAIL=\K.*' || true)
+    fi
+fi
+
+# -------------------------------------------------------------------------
+# 4. Configure Nginx
+# -------------------------------------------------------------------------
+rm -f /etc/nginx/sites-enabled/default
+cp "${AK_DIR}/nginx-host.conf" /etc/nginx/sites-available/artifact-keeper
+ln -sf /etc/nginx/sites-available/artifact-keeper /etc/nginx/sites-enabled/artifact-keeper
+
+if [ -n "$DOMAIN" ]; then
+    sed -i "s/server_name _;/server_name ${DOMAIN};/" /etc/nginx/sites-available/artifact-keeper
+fi
+
+nginx -t && systemctl restart nginx
+
+# -------------------------------------------------------------------------
+# 5. Configure SSL if domain provided
+# -------------------------------------------------------------------------
+if [ -n "$DOMAIN" ] && [ -n "$ADMIN_EMAIL" ]; then
+    echo "==> Configuring SSL for ${DOMAIN}"
+    certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m "$ADMIN_EMAIL" --redirect || \
+        echo "WARNING: Certbot failed — continuing without SSL"
+fi
+
+# -------------------------------------------------------------------------
+# 6. Enable firewall
+# -------------------------------------------------------------------------
+ufw --force enable
+
+# -------------------------------------------------------------------------
+# 7. Get public IP for credentials file
+# -------------------------------------------------------------------------
+PUBLIC_IP=""
+if [ -n "$TOKEN" ]; then
+    PUBLIC_IP=$(curl -s --max-time 2 -H "X-aws-ec2-metadata-token: ${TOKEN}" \
+        "http://169.254.169.254/latest/meta-data/public-ipv4" 2>/dev/null || echo "YOUR_IP")
+fi
+
+# -------------------------------------------------------------------------
+# 8. Write credentials file
+# -------------------------------------------------------------------------
+cat > "$CREDS_FILE" <<CREDS
+=====================================
+  Artifact Keeper Credentials
+=====================================
+
+Access URL: ${DOMAIN:+https://${DOMAIN}}${DOMAIN:-http://${PUBLIC_IP:-YOUR_IP}}
+
+Database Password:  ${DB_PASSWORD}
+Meilisearch Key:    ${MEILI_KEY}
+JWT Secret:         ${JWT_SECRET}
+
+Docker Compose Dir: ${AK_DIR}
+
+Manage services:
+  cd ${AK_DIR}
+  docker compose ps
+  docker compose logs -f backend
+  docker compose restart
+
+=====================================
+CREDS
+chmod 600 "$CREDS_FILE"
+
+touch "$MARKER"
+echo "==> First boot complete! Credentials saved to ${CREDS_FILE}"

--- a/aws-scripts/nginx-host.conf
+++ b/aws-scripts/nginx-host.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    client_max_body_size 0;
+    proxy_request_buffering off;
+
+    # Frontend (serves UI and proxies API via its own nginx)
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # Health check directly to backend
+    location /health {
+        proxy_pass http://127.0.0.1:8080/health;
+    }
+}

--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -1,0 +1,89 @@
+# Demo deployment for demo.artifactkeeper.com
+# Uses pre-built images from ghcr.io (pushed by CI on every main branch commit).
+# All write operations are blocked via DEMO_MODE.
+# Reset daily with: ./reset-demo.sh
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: artifact_registry
+      POSTGRES_USER: registry
+      POSTGRES_PASSWORD: registry-demo
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d artifact_registry"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:latest
+    user: "0:0"
+    environment:
+      DATABASE_URL: postgres://registry:registry-demo@postgres:5432/artifact_registry
+      BIND_ADDRESS: 0.0.0.0:8080
+      STORAGE_BACKEND: filesystem
+      STORAGE_PATH: /data/storage
+      JWT_SECRET: demo-instance-jwt-secret-not-for-production
+      DEMO_MODE: "true"
+      TRIVY_URL: http://trivy:8090
+      OPENSCAP_URL: http://openscap:8091
+      SCAN_WORKSPACE_PATH: /scan-workspace
+      LOG_LEVEL: info
+    ports:
+      - "8080:8080"
+    volumes:
+      - artifact_data:/data
+      - scan_workspace:/scan-workspace
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  trivy:
+    image: aquasec/trivy:latest
+    command: ["server", "--listen", "0.0.0.0:8090"]
+    volumes:
+      - trivy_cache:/root/.cache/trivy
+      - scan_workspace:/scan-workspace:ro
+
+  openscap:
+    image: ghcr.io/artifact-keeper/artifact-keeper-openscap:latest
+    volumes:
+      - scan_workspace:/scan-workspace:ro
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8091/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  web:
+    image: ghcr.io/artifact-keeper/artifact-keeper-web:latest
+    environment:
+      BACKEND_URL: http://backend:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+  # Seed container — runs once then exits
+  seed:
+    image: postgres:15-alpine
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./seed-demo-data.sql:/seed.sql:ro
+    entrypoint: >
+      sh -c "
+        sleep 5 &&
+        PGPASSWORD=registry-demo psql -h postgres -U registry -d artifact_registry -f /seed.sql &&
+        echo 'Demo data seeded successfully'
+      "
+
+volumes:
+  postgres_data:
+  artifact_data:
+  trivy_cache:
+  scan_workspace:

--- a/demo/reset-demo.sh
+++ b/demo/reset-demo.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Reset the demo instance to a clean state.
+# Intended to run as a daily cron job on the demo EC2 host.
+#
+# Crontab example:
+#   0 4 * * * /opt/artifact-keeper-iac/demo/reset-demo.sh >> /var/log/demo-reset.log 2>&1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Starting demo reset..."
+
+# Bring everything down and remove volumes
+docker compose -f docker-compose.demo.yml down -v
+
+# Pull latest images
+docker compose -f docker-compose.demo.yml pull
+
+# Start fresh
+docker compose -f docker-compose.demo.yml up -d
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Demo reset complete."

--- a/demo/seed-demo-data.sql
+++ b/demo/seed-demo-data.sql
@@ -1,0 +1,358 @@
+-- Demo seed data for demo.artifactkeeper.com
+-- Idempotent: safe to run multiple times.
+-- All write operations are blocked by DEMO_MODE in the backend.
+
+-- Create demo users (password is "demo" for all accounts)
+-- Use ON CONFLICT DO UPDATE for admin so we always set the demo password
+INSERT INTO users (id, username, email, password_hash, display_name, is_admin, is_active, must_change_password, created_at)
+VALUES
+  ('00000000-0000-0000-0000-000000000002', 'developer', 'dev@demo.artifactkeeper.com',
+   '$2b$12$hz/7VwvP.R7vwpyYKbzE0ud.7G058qWPdRNRUWakNU5dyipzllIde',
+   'Jane Developer', false, true, false, NOW() - interval '150 days'),
+  ('00000000-0000-0000-0000-000000000003', 'viewer', 'viewer@demo.artifactkeeper.com',
+   '$2b$12$hz/7VwvP.R7vwpyYKbzE0ud.7G058qWPdRNRUWakNU5dyipzllIde',
+   'Read-Only User', false, true, false, NOW() - interval '120 days'),
+  ('00000000-0000-0000-0000-000000000004', 'ci-bot', 'ci@demo.artifactkeeper.com',
+   '$2b$12$hz/7VwvP.R7vwpyYKbzE0ud.7G058qWPdRNRUWakNU5dyipzllIde',
+   'CI Pipeline Bot', false, true, false, NOW() - interval '170 days')
+ON CONFLICT (username) DO NOTHING;
+
+-- Update admin password to "demo" regardless of existing hash
+UPDATE users
+SET password_hash = '$2b$12$hz/7VwvP.R7vwpyYKbzE0ud.7G058qWPdRNRUWakNU5dyipzllIde',
+    must_change_password = false
+WHERE username = 'admin';
+
+-- Store admin ID for FK references
+DO $$
+DECLARE admin_id uuid;
+BEGIN
+  SELECT id INTO admin_id FROM users WHERE username = 'admin';
+
+  -- ============================================================================
+  -- Repositories — public and private across many formats
+  -- ============================================================================
+
+  INSERT INTO repositories (id, key, name, description, format, repo_type, storage_path, is_public, created_at)
+  VALUES
+    -- Public repositories
+    ('10000000-0000-0000-0000-000000000001', 'maven-releases', 'Maven Releases',
+     'Production-ready Java/Kotlin artifacts. All releases go through full CI/CD pipeline with Trivy scanning.',
+     'maven', 'local', '/data/storage/maven-releases', true, NOW() - interval '180 days'),
+
+    ('10000000-0000-0000-0000-000000000002', 'npm-public', 'NPM Public',
+     'Open-source npm packages published by the team. Includes design system, CLI tools, and shared configs.',
+     'npm', 'local', '/data/storage/npm-public', true, NOW() - interval '160 days'),
+
+    ('10000000-0000-0000-0000-000000000003', 'docker-images', 'Docker Images',
+     'Container images for all microservices. Multi-arch builds (amd64/arm64). Scanned on every push.',
+     'docker', 'local', '/data/storage/docker-images', true, NOW() - interval '150 days'),
+
+    ('10000000-0000-0000-0000-000000000004', 'pypi-packages', 'PyPI Packages',
+     'Python packages for data engineering and ML pipelines. Compatible with pip and Poetry.',
+     'pypi', 'local', '/data/storage/pypi-packages', true, NOW() - interval '140 days'),
+
+    ('10000000-0000-0000-0000-000000000005', 'helm-charts', 'Helm Charts',
+     'Kubernetes Helm charts for production deployments. Includes monitoring, ingress, and service mesh.',
+     'helm', 'local', '/data/storage/helm-charts', true, NOW() - interval '130 days'),
+
+    ('10000000-0000-0000-0000-000000000006', 'cargo-crates', 'Cargo Crates',
+     'Internal Rust crates for high-performance services. Shared serialization, networking, and crypto libraries.',
+     'cargo', 'local', '/data/storage/cargo-crates', true, NOW() - interval '120 days'),
+
+    ('10000000-0000-0000-0000-000000000007', 'nuget-packages', 'NuGet Packages',
+     '.NET packages for backend services and shared libraries. Targets .NET 8 LTS.',
+     'nuget', 'local', '/data/storage/nuget-packages', true, NOW() - interval '110 days'),
+
+    ('10000000-0000-0000-0000-000000000008', 'go-modules', 'Go Modules',
+     'Go modules for CLI tools and infrastructure automation. Uses Go 1.22+ with generics.',
+     'go', 'local', '/data/storage/go-modules', true, NOW() - interval '100 days'),
+
+    ('10000000-0000-0000-0000-000000000009', 'debian-packages', 'Debian Packages',
+     'APT repository for Ubuntu/Debian server packages. GPG-signed with automated builds.',
+     'debian', 'local', '/data/storage/debian-packages', true, NOW() - interval '90 days'),
+
+    ('10000000-0000-0000-0000-000000000010', 'rpm-packages', 'RPM Packages',
+     'YUM/DNF repository for RHEL/Fedora/CentOS packages. RPM-signed releases.',
+     'rpm', 'local', '/data/storage/rpm-packages', true, NOW() - interval '85 days'),
+
+    -- Private repositories
+    ('10000000-0000-0000-0000-000000000011', 'npm-internal', 'NPM Internal',
+     'Private npm packages for internal microservices. Includes auth middleware, logging, and API clients.',
+     'npm', 'local', '/data/storage/npm-internal', false, NOW() - interval '155 days'),
+
+    ('10000000-0000-0000-0000-000000000012', 'docker-staging', 'Docker Staging',
+     'Pre-release container images for staging environment. Auto-cleaned after 30 days.',
+     'docker', 'local', '/data/storage/docker-staging', false, NOW() - interval '120 days'),
+
+    ('10000000-0000-0000-0000-000000000013', 'maven-snapshots', 'Maven Snapshots',
+     'Development snapshots from CI. Retained for 14 days. Not for production use.',
+     'maven', 'local', '/data/storage/maven-snapshots', false, NOW() - interval '175 days'),
+
+    ('10000000-0000-0000-0000-000000000014', 'terraform-modules', 'Terraform Modules',
+     'Infrastructure-as-code modules for AWS, GCP, and Azure. Versioned with semantic versioning.',
+     'terraform', 'local', '/data/storage/terraform-modules', false, NOW() - interval '70 days'),
+
+    ('10000000-0000-0000-0000-000000000015', 'conda-packages', 'Conda Packages',
+     'Data science packages for Conda environments. Includes GPU-optimized builds.',
+     'conda', 'local', '/data/storage/conda-packages', false, NOW() - interval '60 days')
+  ON CONFLICT (key) DO NOTHING;
+
+  -- ============================================================================
+  -- Artifacts (use admin_id for admin-uploaded, fixed IDs for other users)
+  -- ============================================================================
+
+  -- Maven Releases
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:auth-service', '2.4.1',
+     'com/example/auth-service/2.4.1/auth-service-2.4.1.jar', 4521984,
+     'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2', 'application/java-archive',
+     'maven-releases/com/example/auth-service/2.4.1/auth-service-2.4.1.jar',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '30 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:payment-gateway', '1.8.0',
+     'com/example/payment-gateway/1.8.0/payment-gateway-1.8.0.jar', 3145728,
+     'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3', 'application/java-archive',
+     'maven-releases/com/example/payment-gateway/1.8.0/payment-gateway-1.8.0.jar',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '25 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:user-api', '3.1.0',
+     'com/example/user-api/3.1.0/user-api-3.1.0.jar', 2097152,
+     'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4', 'application/java-archive',
+     'maven-releases/com/example/user-api/3.1.0/user-api-3.1.0.jar',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '20 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:notification-service', '1.2.3',
+     'com/example/notification-service/1.2.3/notification-service-1.2.3.jar', 1572864,
+     'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5', 'application/java-archive',
+     'maven-releases/com/example/notification-service/1.2.3/notification-service-1.2.3.jar',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '15 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:commons-utils', '5.0.2',
+     'com/example/commons-utils/5.0.2/commons-utils-5.0.2.jar', 524288,
+     'e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6', 'application/java-archive',
+     'maven-releases/com/example/commons-utils/5.0.2/commons-utils-5.0.2.jar',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '10 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000001', 'com.example:event-bus', '2.0.0',
+     'com/example/event-bus/2.0.0/event-bus-2.0.0.jar', 1835008,
+     'f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1', 'application/java-archive',
+     'maven-releases/com/example/event-bus/2.0.0/event-bus-2.0.0.jar',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '5 days')
+  ON CONFLICT DO NOTHING;
+
+  -- NPM Public
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000002', '@acme/design-system', '4.2.0',
+     '@acme/design-system/-/design-system-4.2.0.tgz', 1048576,
+     'a1a2a3a4a5a6a7a8a9a0b1b2b3b4b5b6b7b8b9b0c1c2c3c4c5c6c7c8c9c0d1d2', 'application/gzip',
+     'npm-public/@acme/design-system/-/design-system-4.2.0.tgz',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '28 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000002', '@acme/eslint-config', '2.1.0',
+     '@acme/eslint-config/-/eslint-config-2.1.0.tgz', 32768,
+     'b1b2b3b4b5b6b7b8b9b0c1c2c3c4c5c6c7c8c9c0d1d2d3d4d5d6d7d8d9d0e1e2', 'application/gzip',
+     'npm-public/@acme/eslint-config/-/eslint-config-2.1.0.tgz',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '22 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000002', '@acme/api-client', '3.5.1',
+     '@acme/api-client/-/api-client-3.5.1.tgz', 262144,
+     'c1c2c3c4c5c6c7c8c9c0d1d2d3d4d5d6d7d8d9d0e1e2e3e4e5e6e7e8e9e0f1f2', 'application/gzip',
+     'npm-public/@acme/api-client/-/api-client-3.5.1.tgz',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '18 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000002', '@acme/react-hooks', '1.8.0',
+     '@acme/react-hooks/-/react-hooks-1.8.0.tgz', 98304,
+     'd1d2d3d4d5d6d7d8d9d0e1e2e3e4e5e6e7e8e9e0f1f2f3f4f5f6f7f8f9f0a1a2', 'application/gzip',
+     'npm-public/@acme/react-hooks/-/react-hooks-1.8.0.tgz',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '12 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000002', '@acme/logger', '1.0.8',
+     '@acme/logger/-/logger-1.0.8.tgz', 65536,
+     'e1e2e3e4e5e6e7e8e9e0f1f2f3f4f5f6f7f8f9f0a1a2a3a4a5a6a7a8a9a0b1b2', 'application/gzip',
+     'npm-public/@acme/logger/-/logger-1.0.8.tgz',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '8 days')
+  ON CONFLICT DO NOTHING;
+
+  -- Docker Images
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000003', 'api-gateway', 'v2.1.0',
+     'api-gateway/v2.1.0/manifest.json', 157286400,
+     'f1f2f3f4f5f6f7f8f9f0a1a2a3a4a5a6a7a8a9a0b1b2b3b4b5b6b7b8b9b0c1c2', 'application/vnd.docker.distribution.manifest.v2+json',
+     'docker-images/api-gateway/v2.1.0/manifest.json',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '14 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000003', 'web-frontend', 'v3.0.0',
+     'web-frontend/v3.0.0/manifest.json', 209715200,
+     'a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3', 'application/vnd.docker.distribution.manifest.v2+json',
+     'docker-images/web-frontend/v3.0.0/manifest.json',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '7 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000003', 'worker-service', 'v1.5.2',
+     'worker-service/v1.5.2/manifest.json', 104857600,
+     'b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4', 'application/vnd.docker.distribution.manifest.v2+json',
+     'docker-images/worker-service/v1.5.2/manifest.json',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '3 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000003', 'ml-inference', 'v0.9.1',
+     'ml-inference/v0.9.1/manifest.json', 524288000,
+     'c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5', 'application/vnd.docker.distribution.manifest.v2+json',
+     'docker-images/ml-inference/v0.9.1/manifest.json',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '1 day')
+  ON CONFLICT DO NOTHING;
+
+  -- PyPI Packages
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000004', 'acme-ml-pipeline', '1.3.0',
+     'acme-ml-pipeline/1.3.0/acme_ml_pipeline-1.3.0-py3-none-any.whl', 2097152,
+     'd5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6', 'application/zip',
+     'pypi-packages/acme-ml-pipeline/1.3.0/acme_ml_pipeline-1.3.0-py3-none-any.whl',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '21 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000004', 'acme-data-utils', '2.0.1',
+     'acme-data-utils/2.0.1/acme_data_utils-2.0.1-py3-none-any.whl', 524288,
+     'e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7', 'application/zip',
+     'pypi-packages/acme-data-utils/2.0.1/acme_data_utils-2.0.1-py3-none-any.whl',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '16 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000004', 'acme-auth-sdk', '3.2.0',
+     'acme-auth-sdk/3.2.0/acme_auth_sdk-3.2.0-py3-none-any.whl', 131072,
+     'f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8', 'application/zip',
+     'pypi-packages/acme-auth-sdk/3.2.0/acme_auth_sdk-3.2.0-py3-none-any.whl',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '9 days')
+  ON CONFLICT DO NOTHING;
+
+  -- Helm Charts (use admin_id for admin-uploaded ones)
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000005', 'api-gateway-chart', '1.5.0',
+     'api-gateway-chart-1.5.0.tgz', 32768,
+     'a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9', 'application/gzip',
+     'helm-charts/api-gateway-chart-1.5.0.tgz',
+     admin_id, NOW() - interval '19 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000005', 'monitoring-stack', '2.0.0',
+     'monitoring-stack-2.0.0.tgz', 65536,
+     'b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0', 'application/gzip',
+     'helm-charts/monitoring-stack-2.0.0.tgz',
+     admin_id, NOW() - interval '11 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000005', 'redis-ha', '3.1.2',
+     'redis-ha-3.1.2.tgz', 16384,
+     'c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1', 'application/gzip',
+     'helm-charts/redis-ha-3.1.2.tgz',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '6 days')
+  ON CONFLICT DO NOTHING;
+
+  -- Cargo Crates
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000006', 'acme-proto', '0.12.0',
+     'acme-proto/0.12.0/acme-proto-0.12.0.crate', 262144,
+     'aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44', 'application/gzip',
+     'cargo-crates/acme-proto/0.12.0/acme-proto-0.12.0.crate',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '35 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000006', 'acme-crypto', '1.4.0',
+     'acme-crypto/1.4.0/acme-crypto-1.4.0.crate', 196608,
+     'bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55', 'application/gzip',
+     'cargo-crates/acme-crypto/1.4.0/acme-crypto-1.4.0.crate',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '20 days')
+  ON CONFLICT DO NOTHING;
+
+  -- NuGet Packages
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000007', 'Acme.Core', '6.1.0',
+     'acme.core/6.1.0/acme.core.6.1.0.nupkg', 524288,
+     'dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11', 'application/octet-stream',
+     'nuget-packages/acme.core/6.1.0/acme.core.6.1.0.nupkg',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '40 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000007', 'Acme.EntityFramework', '3.0.2',
+     'acme.entityframework/3.0.2/acme.entityframework.3.0.2.nupkg', 393216,
+     'ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22cc33dd44ee55ff66aa11bb22', 'application/octet-stream',
+     'nuget-packages/acme.entityframework/3.0.2/acme.entityframework.3.0.2.nupkg',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '18 days')
+  ON CONFLICT DO NOTHING;
+
+  -- Go Modules
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000008', 'github.com/acme/infra-cli', 'v1.7.0',
+     'github.com/acme/infra-cli/@v/v1.7.0.zip', 3145728,
+     '1122334455667788990011223344556677889900112233445566778899001122', 'application/zip',
+     'go-modules/github.com/acme/infra-cli/@v/v1.7.0.zip',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '15 days')
+  ON CONFLICT DO NOTHING;
+
+  -- Debian Packages
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000009', 'acme-agent', '1.2.0-1',
+     'pool/main/a/acme-agent/acme-agent_1.2.0-1_amd64.deb', 8388608,
+     '3344556677889900112233445566778899001122334455667788990011223344', 'application/vnd.debian.binary-package',
+     'debian-packages/pool/main/a/acme-agent/acme-agent_1.2.0-1_amd64.deb',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '22 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000009', 'acme-collector', '0.9.5-1',
+     'pool/main/a/acme-collector/acme-collector_0.9.5-1_amd64.deb', 4194304,
+     '4455667788990011223344556677889900112233445566778899001122334455', 'application/vnd.debian.binary-package',
+     'debian-packages/pool/main/a/acme-collector/acme-collector_0.9.5-1_amd64.deb',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '10 days')
+  ON CONFLICT DO NOTHING;
+
+  -- RPM Packages
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000010', 'acme-agent', '1.2.0-1.el9',
+     'Packages/acme-agent-1.2.0-1.el9.x86_64.rpm', 9437184,
+     '5566778899001122334455667788990011223344556677889900112233445566', 'application/x-rpm',
+     'rpm-packages/Packages/acme-agent-1.2.0-1.el9.x86_64.rpm',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '22 days')
+  ON CONFLICT DO NOTHING;
+
+  -- NPM Internal (private)
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000011', '@acme-internal/auth-middleware', '2.0.3',
+     '@acme-internal/auth-middleware/-/auth-middleware-2.0.3.tgz', 131072,
+     '7788990011223344556677889900112233445566778899001122334455667788', 'application/gzip',
+     'npm-internal/@acme-internal/auth-middleware/-/auth-middleware-2.0.3.tgz',
+     '00000000-0000-0000-0000-000000000002', NOW() - interval '5 days'),
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000011', '@acme-internal/feature-flags', '0.4.1',
+     '@acme-internal/feature-flags/-/feature-flags-0.4.1.tgz', 49152,
+     '9900112233445566778899001122334455667788990011223344556677889900', 'application/gzip',
+     'npm-internal/@acme-internal/feature-flags/-/feature-flags-0.4.1.tgz',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '1 day')
+  ON CONFLICT DO NOTHING;
+
+  -- Docker Staging (private)
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000012', 'api-gateway', 'v2.2.0-rc3',
+     'api-gateway/v2.2.0-rc3/manifest.json', 162529280,
+     'aabb11223344556677889900aabbccddeeff00112233445566778899aabbccdd', 'application/vnd.docker.distribution.manifest.v2+json',
+     'docker-staging/api-gateway/v2.2.0-rc3/manifest.json',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '1 day')
+  ON CONFLICT DO NOTHING;
+
+  -- Maven Snapshots (private)
+  INSERT INTO artifacts (id, repository_id, name, version, path, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by, created_at)
+  VALUES
+    (gen_random_uuid(), '10000000-0000-0000-0000-000000000013', 'com.example:auth-service', '2.5.0-SNAPSHOT',
+     'com/example/auth-service/2.5.0-SNAPSHOT/auth-service-2.5.0-20260131.jar', 4653056,
+     'ccdd11223344556677889900aabbccddeeff00112233445566778899aabbccdd', 'application/java-archive',
+     'maven-snapshots/com/example/auth-service/2.5.0-SNAPSHOT/auth-service-2.5.0-20260131.jar',
+     '00000000-0000-0000-0000-000000000004', NOW() - interval '3 hours')
+  ON CONFLICT DO NOTHING;
+
+  -- ============================================================================
+  -- Audit log entries (correlation_id is required NOT NULL uuid)
+  -- ============================================================================
+
+  INSERT INTO audit_log (id, user_id, action, resource_type, resource_id, details, ip_address, correlation_id, created_at)
+  VALUES
+    (gen_random_uuid(), admin_id, 'create', 'repository', NULL,
+     '{"key": "maven-releases", "format": "maven"}',
+     '10.0.1.1', gen_random_uuid(), NOW() - interval '180 days'),
+    (gen_random_uuid(), '00000000-0000-0000-0000-000000000002', 'upload', 'artifact', NULL,
+     '{"name": "com.example:auth-service", "version": "2.4.1", "repo": "maven-releases"}',
+     '10.0.1.50', gen_random_uuid(), NOW() - interval '30 days'),
+    (gen_random_uuid(), '00000000-0000-0000-0000-000000000004', 'upload', 'artifact', NULL,
+     '{"name": "api-gateway", "version": "v2.1.0", "repo": "docker-images"}',
+     '10.0.1.100', gen_random_uuid(), NOW() - interval '14 days'),
+    (gen_random_uuid(), '00000000-0000-0000-0000-000000000003', 'download', 'artifact', NULL,
+     '{"name": "@acme/api-client", "version": "3.5.1", "repo": "npm-public"}',
+     '10.0.2.101', gen_random_uuid(), NOW() - interval '5 days'),
+    (gen_random_uuid(), admin_id, 'scan', 'repository', NULL,
+     '{"repo": "docker-images", "scanner": "trivy", "vulnerabilities": {"critical": 0, "high": 2, "medium": 5}}',
+     '10.0.1.1', gen_random_uuid(), NOW() - interval '2 days')
+  ON CONFLICT DO NOTHING;
+
+END $$;

--- a/packer/artifact-keeper.pkr.hcl
+++ b/packer/artifact-keeper.pkr.hcl
@@ -1,0 +1,106 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.3.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+
+variable "artifact_keeper_version" {
+  type        = string
+  default     = "latest"
+  description = "Docker image tag to bake into the AMI (e.g. latest, 0.2.0, main)."
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}
+
+variable "ami_regions" {
+  type        = list(string)
+  default     = []
+  description = "Additional regions to copy the AMI to. Empty = only build region."
+}
+
+# -----------------------------------------------------------------------------
+# Source: Amazon EBS (Ubuntu 24.04 LTS)
+# -----------------------------------------------------------------------------
+
+source "amazon-ebs" "artifact-keeper" {
+  ami_name        = "artifact-keeper-${var.artifact_keeper_version}-{{timestamp}}"
+  ami_description = "Artifact Keeper ${var.artifact_keeper_version} - open-source artifact registry with PostgreSQL, Meilisearch, and Trivy."
+  instance_type   = var.instance_type
+  region          = var.aws_region
+  ami_regions     = var.ami_regions
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"] # Canonical
+  }
+
+  ssh_username = "ubuntu"
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name        = "artifact-keeper-${var.artifact_keeper_version}"
+    Application = "artifact-keeper"
+    Version     = var.artifact_keeper_version
+    OS          = "ubuntu-24.04"
+    ManagedBy   = "packer"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Build
+# -----------------------------------------------------------------------------
+
+build {
+  sources = ["source.amazon-ebs.artifact-keeper"]
+
+  # Create destination directory first
+  provisioner "shell" {
+    inline = ["mkdir -p /tmp/ak-scripts"]
+  }
+
+  # Upload scripts and compose file
+  provisioner "file" {
+    source      = "${path.root}/../scripts/"
+    destination = "/tmp/ak-scripts"
+  }
+
+  # Install Docker and pull images
+  provisioner "shell" {
+    environment_vars = [
+      "ARTIFACT_KEEPER_VERSION=${var.artifact_keeper_version}",
+      "DEBIAN_FRONTEND=noninteractive",
+    ]
+    execute_command = "chmod +x {{ .Path }}; sudo -E {{ .Path }}"
+    scripts = [
+      "${path.root}/../scripts/01-docker.sh",
+      "${path.root}/../scripts/02-artifact-keeper.sh",
+      "${path.root}/../scripts/99-cleanup.sh",
+    ]
+  }
+}

--- a/packer/variables.auto.pkrvars.hcl.example
+++ b/packer/variables.auto.pkrvars.hcl.example
@@ -1,0 +1,6 @@
+artifact_keeper_version = "latest"
+aws_region              = "us-east-1"
+instance_type           = "t3.medium"
+
+# Copy AMI to additional regions (optional)
+# ami_regions = ["us-west-2", "eu-west-1", "ap-southeast-1"]


### PR DESCRIPTION
## Summary

- Adds `demo/` — docker-compose, reset script, and seed SQL for demo.artifactkeeper.com
- Adds `packer/` — Packer HCL template for AMI builds
- Adds `aws-scripts/` — EC2 provisioning scripts (Docker install, first-boot, nginx, cleanup)

These files were previously in `artifact-keeper/deploy/` and belong in the IAC repo.

## Test plan

- [ ] Verify packer validate passes with the relocated template
- [ ] Verify demo compose starts correctly from the new path

> **Merge this first** — the companion backend PR (artifact-keeper/artifact-keeper#TBD) updates `ami-build.yml` to checkout this repo for packer files.