### PR TITLE
Add cosign image signature verification to Helm chart

### DIFF
--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -33,6 +33,17 @@ spec:
         runAsUser: 1000
         fsGroup: 1000
       initContainers:
+        {{- if .Values.cosign.enabled }}
+        - name: verify-image-signature
+          image: "{{ .Values.cosign.image.repository }}:{{ .Values.cosign.image.tag }}"
+          command: ["cosign", "verify",
+            "--certificate-oidc-issuer={{ .Values.cosign.certificateOidcIssuer }}",
+            "--certificate-identity-regexp={{ .Values.cosign.certificateIdentityRegexp }}",
+            "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"]
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+        {{- end }}
         {{- if .Values.postgres.enabled }}
         - name: wait-for-postgres
           image: {{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,18 @@ global:
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Cosign image signature verification
+# When enabled, an init container verifies the backend image signature
+# before the pod starts. Uses sigstore keyless verification (GitHub OIDC).
+cosign:
+  enabled: false
+  image:
+    repository: gcr.io/projectsigstore/cosign
+    tag: v2.4.1
+  # OIDC issuer and identity for keyless verification
+  certificateOidcIssuer: "https://token.actions.githubusercontent.com"
+  certificateIdentityRegexp: "https://github.com/artifact-keeper/.*"
+
 # -- Backend API server
 backend:
   enabled: true


### PR DESCRIPTION
## Summary
- Add `cosign` config block to `values.yaml` (opt-in via `cosign.enabled`)
- Add cosign verify init container to backend deployment that validates image signature before pod starts
- Uses sigstore keyless verification with GitHub OIDC issuer

## Usage
```yaml
# values-production.yaml
cosign:
  enabled: true
  certificateOidcIssuer: "https://token.actions.githubusercontent.com"
  certificateIdentityRegexp: "https://github.com/artifact-keeper/.*"
```

## Test plan
- [ ] Deploy with `cosign.enabled: false` (default) — no init container added
- [ ] Deploy with `cosign.enabled: true` — init container verifies signed image before backend starts
- [ ] Deploy with unsigned image + `cosign.enabled: true` — pod fails to start (expected)