### PR TITLE
fix: add backend DNS alias for web proxy

### DIFF
--- a/helm/templates/backend-alias-service.yaml
+++ b/helm/templates/backend-alias-service.yaml
@@ -1,0 +1,23 @@
+{{/*
+=============================================================================
+Backend DNS Alias
+=============================================================================
+The Next.js web image bakes BACKEND_URL into its rewrites at build time
+(Dockerfile ARG default: http://backend:8080). This ExternalName service
+creates a "backend" DNS alias in each namespace so the baked-in hostname
+resolves to the Helm-named backend service regardless of the release name.
+=============================================================================
+*/}}
+{{- if and .Values.backend.enabled .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend-alias
+spec:
+  type: ExternalName
+  externalName: {{ include "artifact-keeper.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds an ExternalName service named `backend` that aliases to the Helm-named backend service
- Fixes Next.js rewrite proxy which bakes `http://backend:8080` at Docker build time

## Problem
Next.js `rewrites()` in `next.config.ts` are evaluated at build time, not runtime. The Dockerfile default `ARG BACKEND_URL=http://backend:8080` gets baked into the routes manifest. In namespaces where the Helm release name isn't just "backend" (e.g., `artifact-keeper-dev-backend`), DNS resolution fails.

## Solution
An ExternalName service creates a `backend` CNAME in each namespace pointing to the full Helm-named service, making the baked-in hostname work everywhere.