### PR TITLE
chore: parameterize demo image tags

### DIFF
--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/artifact-keeper/artifact-keeper-backend:latest
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
     user: "0:0"
     environment:
       DATABASE_URL: postgres://registry:registry-demo@postgres:5432/artifact_registry
@@ -49,7 +49,7 @@ services:
       - scan_workspace:/scan-workspace:ro
 
   openscap:
-    image: ghcr.io/artifact-keeper/artifact-keeper-openscap:latest
+    image: ghcr.io/artifact-keeper/artifact-keeper-openscap:${ARTIFACT_KEEPER_VERSION:-latest}
     volumes:
       - scan_workspace:/scan-workspace:ro
     healthcheck:
@@ -59,7 +59,7 @@ services:
       retries: 3
 
   web:
-    image: ghcr.io/artifact-keeper/artifact-keeper-web:latest
+    image: ghcr.io/artifact-keeper/artifact-keeper-web:${ARTIFACT_KEEPER_VERSION:-latest}
     environment:
       BACKEND_URL: http://backend:8080
     ports:


### PR DESCRIPTION
## Summary
- Replace hardcoded `:latest` tags with `${ARTIFACT_KEEPER_VERSION:-latest}` in demo compose
- Allows pinning the demo to a specific release (e.g., `v1.1.0-rc.2`) via `.env` file
- Matches the pattern already used in `aws-scripts/docker-compose.yml`

## Usage
```bash
# Pin to specific version
echo "ARTIFACT_KEEPER_VERSION=v1.1.0-rc.2" > .env
docker compose -f docker-compose.demo.yml pull && docker compose -f docker-compose.demo.yml up -d

# Use latest (default)
docker compose -f docker-compose.demo.yml pull && docker compose -f docker-compose.demo.yml up -d
```