### PR TITLE
Add version pinning docs to demo compose file

### DIFF
--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -2,6 +2,11 @@
 # Uses pre-built images from ghcr.io (pushed by CI on every main branch commit).
 # All write operations are blocked via DEMO_MODE.
 # Reset daily with: ./reset-demo.sh
+#
+# Version pinning: create a .env file next to this compose file with:
+#   ARTIFACT_KEEPER_VERSION=1.1.0-rc.2
+# Note: Docker tags use semver WITHOUT the 'v' prefix (git tag v1.1.0-rc.2 → Docker tag 1.1.0-rc.2).
+# If ARTIFACT_KEEPER_VERSION is unset, defaults to 'latest' (latest stable release).
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
- Add header comment explaining `ARTIFACT_KEEPER_VERSION` env var usage
- Document that Docker tags use semver without `v` prefix
- Note default behavior when variable is unset (falls back to `latest`)