### PR TITLE
Bump meilisearch memory limit from 1Gi to 4Gi

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -204,10 +204,10 @@ meilisearch:
   resources:
     requests:
       cpu: 250m
-      memory: 256Mi
+      memory: 512Mi
     limits:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "2"
+      memory: 4Gi
   # -- Per-component scheduling (overrides global)
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary
- Bumped meilisearch default memory request from 256Mi to 512Mi and limit from 1Gi to 4Gi
- Meilisearch v1.12 spawns 28 HTTP workers (actix) matching CPU core count, which exceeds 1Gi on multi-core nodes
- The artifact-keeper-dev deployment was OOMKilled on every startup with the previous limit

## Context
Found during a container update rollout on the rocky cluster. All other services updated fine but meilisearch kept getting OOMKilled.