### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,18 @@ jobs:
 
       - name: Check formatting
         run: terraform fmt -check -recursive terraform/
+
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `sonarcloud` job to the existing CI workflow that runs on pushes to main and pull requests
- Uses `SonarSource/sonarqube-scan-action@v5` with the existing `sonar-project.properties` configuration
- Requires the `SONAR_TOKEN` repository secret to be configured

## Test plan

- [ ] Verify the `SONAR_TOKEN` secret is set in repository settings
- [ ] Confirm the scan runs successfully on a push to main after merge