### PR TITLE
docs: document Docker Hub as alternative registry

### DIFF
--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -1,5 +1,12 @@
 # Demo deployment for demo.artifactkeeper.com
 # Uses pre-built images from ghcr.io (pushed by CI on every main branch commit).
+#
+# Container images are available from two registries:
+#   ghcr.io (default):  ghcr.io/artifact-keeper/artifact-keeper-{backend,web,openscap}
+#   Docker Hub:         artifactkeeper/{backend,web,openscap}
+#
+# To use Docker Hub instead, replace image references below. For example:
+#   ghcr.io/artifact-keeper/artifact-keeper-backend:latest  ->  artifactkeeper/backend:latest
 # All write operations are blocked via DEMO_MODE.
 # Reset daily with: ./reset-demo.sh
 #

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,6 +40,8 @@
 # Default values for artifact-keeper (development profile)
 
 global:
+  # Container registry prefix. Default is ghcr.io.
+  # For Docker Hub, change to: docker.io/artifactkeeper
   imageRegistry: ghcr.io/artifact-keeper
   imagePullPolicy: Always
   storageClass: standard
@@ -78,7 +80,7 @@ backend:
   enabled: true
   replicaCount: 1
   image:
-    repository: ghcr.io/artifact-keeper/artifact-keeper-backend
+    repository: ghcr.io/artifact-keeper/artifact-keeper-backend  # Docker Hub: artifactkeeper/backend
     # -- "dev" is a floating tag built from main. ArgoCD Image Updater
     # pins this to a digest automatically. For manual deploys, consider
     # using a specific version tag (e.g. 1.1.0).
@@ -135,7 +137,7 @@ web:
   enabled: true
   replicaCount: 1
   image:
-    repository: ghcr.io/artifact-keeper/artifact-keeper-web
+    repository: ghcr.io/artifact-keeper/artifact-keeper-web  # Docker Hub: artifactkeeper/web
     tag: dev
     pullPolicy: Always
   service:


### PR DESCRIPTION
## Summary

- Add Docker Hub registry comment block to `demo/docker-compose.demo.yml`
- Add Docker Hub comments to `helm/values.yaml` on `global.imageRegistry` and individual `repository` fields

Companion PRs in artifact-keeper and artifact-keeper-site.

## Test Plan

- [ ] Verify `docker compose -f demo/docker-compose.demo.yml config` still parses
- [ ] Verify `helm template ./helm` still renders