### PR TITLE
Add ArgoCD permissions to ARC runner RBAC

### DIFF
--- a/e2e/runner-rbac.yaml
+++ b/e2e/runner-rbac.yaml
@@ -3,8 +3,9 @@
 # The ARC Helm chart creates a service account named
 # <release>-gha-rs-no-permission in the runner namespace.
 # This ClusterRole + ClusterRoleBinding grants it the permissions
-# needed by release-gate tests: create/delete test namespaces,
-# deploy Helm charts, collect pod logs, and tear down.
+# needed by release-gate and mesh-e2e tests: create/delete test
+# namespaces, deploy Helm charts, manage ArgoCD apps, collect pod
+# logs, and tear down.
 #
 # Apply with:
 #   kubectl apply -f e2e/runner-rbac.yaml
@@ -27,7 +28,7 @@ rules:
     resources: ["resourcequotas"]
     verbs: ["create", "get", "list", "update", "patch"]
 
-  # Secrets (image pull secrets, Helm release secrets)
+  # Secrets (image pull secrets, Helm release secrets, ArgoCD secrets)
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "get", "list", "update", "patch", "delete"]
@@ -56,6 +57,11 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
     verbs: ["create", "get", "list", "update", "patch", "delete"]
+
+  # ArgoCD Applications (mesh-e2e syncs and monitors ArgoCD apps)
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets", "appprojects"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- Adds argoproj.io API group permissions (applications, applicationsets, appprojects) to the arc-e2e-runner ClusterRole
- Allows mesh-e2e workflow to run on ARC runners (in-cluster) instead of GitHub-hosted runners that can't reach the private K8s API

Already applied to the cluster.