### PR TITLE
fix: add watch verb for secrets in ARC runner RBAC

### DIFF
--- a/e2e/runner-rbac.yaml
+++ b/e2e/runner-rbac.yaml
@@ -31,7 +31,7 @@ rules:
   # Secrets (image pull secrets, Helm release secrets, ArgoCD secrets)
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "get", "list", "update", "patch", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 
   # Core workload resources (Helm chart deploys these)
   - apiGroups: [""]


### PR DESCRIPTION
## Summary
- Added `watch` verb to secrets permissions in the ARC E2E runner ClusterRole
- Helm's release tracking watches secrets in the release namespace, causing deploy failures without this permission

## Test plan
- [x] Applied to cluster via `kubectl apply -f e2e/runner-rbac.yaml`
- [x] Verified with `kubectl auth can-i watch secrets --as=system:serviceaccount:arc-runners:ak-e2e-runners-gha-rs-no-permission`