### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,132 @@
+name: Bug Report
+description: Report a bug with Helm charts, Terraform modules, or deployment configurations
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        If you're experiencing a bug with the **backend API or server**, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+        If the bug is in the **web UI**, please file it in [artifact-keeper-web](https://github.com/artifact-keeper/artifact-keeper-web/issues/new).
+        If you're not sure where the issue belongs, file it here and we'll move it to the right place.
+
+        For security vulnerabilities, please use [private security reporting](https://github.com/artifact-keeper/artifact-keeper-iac/security/advisories/new) instead of a public issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which infrastructure component is affected?
+      options:
+        - Helm Chart
+        - Terraform Module
+        - ArgoCD Configuration
+        - Docker Compose
+        - Kubernetes Manifests
+        - CI/CD Pipelines
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Tell us about your environment.
+      value: |
+        - Kubernetes Version:
+        - Helm Version:
+        - Terraform Version:
+        - Cloud Provider (AWS, GCP, Azure, self-hosted, etc.):
+        - ArgoCD Version (if applicable):
+    validations:
+      required: true
+
+  - type: input
+    id: chart-module-version
+    attributes:
+      label: Chart/Module Version
+      description: The version of the Helm chart or Terraform module you're using.
+      placeholder: "e.g., 1.1.0, latest, dev"
+    validations:
+      required: true
+
+  - type: input
+    id: backend-version
+    attributes:
+      label: Backend Version
+      description: The version of the Artifact Keeper backend, if relevant.
+      placeholder: "e.g., 1.1.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this bug?
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevant-configuration
+    attributes:
+      label: Relevant Configuration
+      description: Paste relevant values.yaml, terraform.tfvars, or other config (redact secrets!).
+      render: yaml
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Paste any relevant log output.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information that might help us investigate.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate.
+          required: true
+        - label: I have redacted all sensitive information (passwords, tokens, internal hostnames).
+          required: true
+        - label: I am using a supported version of the chart or module.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backend / API Issues
+    url: https://github.com/artifact-keeper/artifact-keeper/issues/new
+    about: Report bugs or request features for the backend API and server
+  - name: Web UI Issues
+    url: https://github.com/artifact-keeper/artifact-keeper-web/issues/new
+    about: Report bugs or request features for the web frontend
+  - name: Documentation Issues
+    url: https://github.com/artifact-keeper/artifact-keeper-site/issues/new
+    about: Report issues or suggest improvements for the documentation at artifactkeeper.com
+  - name: Security Vulnerability
+    url: https://github.com/artifact-keeper/artifact-keeper-iac/security/advisories/new
+    about: Please report security vulnerabilities privately through GitHub Security Advisories
+  - name: GitHub Discussions
+    url: https://github.com/orgs/artifact-keeper/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the infrastructure configurations
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+
+        If your request is about the **backend API or server**, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+        This repo covers Helm charts, Terraform modules, and deployment configurations.
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve, or what limitation are you running into?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative approaches or workarounds?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which infrastructure component does this relate to?
+      options:
+        - Helm Chart
+        - Terraform Module
+        - ArgoCD Configuration
+        - Docker Compose
+        - Kubernetes Manifests
+        - CI/CD Pipelines
+        - Monitoring / Observability
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information, examples, or references that would help.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate.
+          required: true
+        - label: I have reviewed the documentation to confirm this is not already supported.
+          required: true


### PR DESCRIPTION
## Summary

- Add structured issue templates for bug reports and feature requests using GitHub's YAML form schema
- Bug report template includes fields for component selection, environment info, reproduction steps, configuration snippets, and logs
- Feature request template includes fields for problem statement, proposed solution, and component selection
- Add config.yml with contact links directing users to the correct repo for backend, web, docs, and security issues

## Test plan

- [ ] Verify templates render correctly at https://github.com/artifact-keeper/artifact-keeper-iac/issues/new/choose
- [ ] Confirm bug report form shows all fields with correct required/optional flags
- [ ] Confirm feature request form shows all fields with correct required/optional flags
- [ ] Confirm contact links point to the correct repositories
- [ ] Verify blank issues are still allowed