### PR TITLE
fix: route native format handlers directly to backend in ingress

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -33,6 +33,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
+          # API and health endpoints
           - path: /api
             pathType: Prefix
             backend:
@@ -61,6 +62,26 @@ spec:
                 name: {{ include "artifact-keeper.fullname" . }}-backend
                 port:
                   number: {{ .Values.backend.service.httpPort }}
+          # OCI / Docker registry
+          - path: /v2
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "artifact-keeper.fullname" . }}-backend
+                port:
+                  number: {{ .Values.backend.service.httpPort }}
+          # Native package format handlers — route directly to backend
+          {{- $backendSvc := printf "%s-backend" (include "artifact-keeper.fullname" .) }}
+          {{- $backendPort := .Values.backend.service.httpPort }}
+          {{- range list "/maven" "/npm" "/pypi" "/nuget" "/cargo" "/gems" "/go" "/helm" "/debian" "/rpm" "/alpine" "/composer" "/conan" "/conda" "/swift" "/terraform" "/cocoapods" "/hex" "/pub" "/lfs" "/ivy" "/chef" "/puppet" "/ansible" "/cran" "/huggingface" "/jetbrains" "/vscode" "/proto" "/incus" "/ext" }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $backendSvc }}
+                port:
+                  number: {{ $backendPort }}
+          {{- end }}
           {{- if .Values.dependencyTrack.enabled }}
           - path: /dtrack
             pathType: Prefix
@@ -70,6 +91,7 @@ spec:
                 port:
                   number: 8080
           {{- end }}
+          # Catch-all: web frontend
           - path: /
             pathType: Prefix
             backend:


### PR DESCRIPTION
## Summary

- Add explicit ingress rules for all 30 native format handler path prefixes (`/maven`, `/npm`, `/pypi`, `/nuget`, `/cargo`, `/gems`, `/go`, `/helm`, etc.) to route directly to the backend service
- Add `/v2` prefix rule for OCI/Docker registry traffic
- Uses a Helm `range` loop to keep the template DRY

## Problem

The ingress template only routed `/api`, `/health`, `/ready`, `/metrics` to the backend. All native format handler paths (`/maven/*`, `/npm/*`, `/pypi/*`, etc.) fell through to the catch-all `/` rule and were served by the web frontend. The Next.js middleware then proxied these requests back to the backend, adding an unnecessary hop that could cause issues with auth header forwarding, binary body handling, and response streaming.

This was contributing to `mvn deploy` failures reported in artifact-keeper/artifact-keeper#361, where Maven could upload artifacts but failed during the download verification step.

## Related

- artifact-keeper/artifact-keeper#376 (matching Caddyfile fix in the backend repo)
- artifact-keeper/artifact-keeper#361 (Maven deploy failure report)

## Test plan

- [ ] `helm template` renders all format handler paths correctly
- [ ] Deploy to staging and verify `mvn deploy` works end-to-end
- [ ] Verify other format handlers (npm, pypi) still work correctly