### PR TITLE
fix: use correct probe endpoints and secretKeyRef for Meilisearch

### DIFF
--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -179,7 +179,10 @@ spec:
             - name: MEILISEARCH_URL
               value: "http://{{ include "artifact-keeper.fullname" . }}-meilisearch:7700"
             - name: MEILISEARCH_API_KEY
-              value: {{ .Values.meilisearch.masterKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "artifact-keeper.fullname" . }}-secrets
+                  key: MEILISEARCH_API_KEY
             {{- end }}
             {{- if .Values.trivy.enabled }}
             - name: TRIVY_URL
@@ -195,19 +198,24 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5

--- a/charts/artifact-keeper/templates/secrets.yaml
+++ b/charts/artifact-keeper/templates/secrets.yaml
@@ -26,6 +26,9 @@ stringData:
   {{- end }}
   S3_ACCESS_KEY: {{ .Values.secrets.s3AccessKey | quote }}
   S3_SECRET_KEY: {{ .Values.secrets.s3SecretKey | quote }}
+  {{- if .Values.meilisearch.enabled }}
+  MEILISEARCH_API_KEY: {{ .Values.meilisearch.masterKey | quote }}
+  {{- end }}
   {{- if .Values.dependencyTrack.enabled }}
   DEPENDENCY_TRACK_ADMIN_PASSWORD: {{ .Values.dependencyTrack.adminPassword | quote }}
   {{- end }}


### PR DESCRIPTION
## Summary

Two Helm chart fixes for the 1.1.0 release gate.

**Probe endpoints:** Changed readiness probe from /health (full rich check) to /readyz (critical deps only: DB, migrations, setup). Changed liveness probe from /health to /livez (basic alive check). Added startup probe using /readyz with failureThreshold=30, periodSeconds=5 (150s max startup window). Removed initialDelaySeconds from readiness and liveness since the startup probe gates them.

This prevents pods from being marked unready when optional services like Meilisearch are misconfigured, while still catching actual critical failures.

**Meilisearch secret:** Changed MEILISEARCH_API_KEY from a plaintext environment variable to a secretKeyRef, sourcing from the existing secrets template.

**Merge order:** This PR depends on artifact-keeper/artifact-keeper#500 (backend must have /readyz and /livez endpoints before probes point at them).

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: N/A
- [ ] ArgoCD: N/A