### PR TITLE
chore: use self-hosted runners for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
   terraform-validate:
     name: Terraform Validate (${{ matrix.env }})
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     strategy:
@@ -35,7 +35,7 @@ jobs:
 
   terraform-fmt:
     name: Terraform Format Check
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   sonarcloud:
     name: SonarCloud Scan
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     # SonarCloud Automatic Analysis may be enabled at the org level.
     # Until it is disabled in the SonarCloud UI (Administration > Analysis Method),
     # CI-based analysis will conflict and fail. Allow this job to fail gracefully

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   template-validation:
     name: "Template & Validate (${{ matrix.variant }})"
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     strategy:
@@ -98,7 +98,7 @@ jobs:
   version-check:
     name: Chart Version Check
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     steps:
@@ -127,7 +127,7 @@ jobs:
 
   install-test:
     name: Install Test (kind)
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     needs: [lint, template-validation]
     permissions:
       contents: read

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   verify:
     name: Verify helm-docs output
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     steps:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   version-check:
     name: Check Version
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: read
     outputs:
@@ -37,7 +37,7 @@ jobs:
     name: Setup GitHub Pages
     needs: version-check
     if: needs.version-check.outputs.changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: write
     steps:
@@ -76,7 +76,7 @@ jobs:
     name: Release Chart
     needs: [version-check, setup-pages]
     if: needs.version-check.outputs.changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Switch all CI workflow jobs from GitHub-hosted `ubuntu-latest` to the self-hosted `ak-ci-runners` scale set on the K8s cluster. Covers ci.yml (terraform validate, fmt, sonarcloud), helm-ci.yml (lint, template-validation, version-check, install-test), helm-docs.yml, and helm-release.yml (version-check, setup-pages, release).

## Test Checklist
- [x] Helm template renders without errors
- [x] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] N/A - documentation only