### PR TITLE
chore(arc): bump ak-e2e-runners maxRunners from 5 to 20

### DIFF
--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -16,7 +16,7 @@ githubConfigSecret: "github-token-secret"
 runnerScaleSetName: "ak-e2e-runners"
 
 minRunners: 0
-maxRunners: 5
+maxRunners: 20
 
 template:
   spec:


### PR DESCRIPTION
## Summary

Bumps the maxRunners cap on the `ak-e2e-runners` autoscaling runner scale set from 5 to 20. Matches `ak-ci-runners` (also 20).

## Why

The release-gate workflow spawns many parallel jobs (formats x8 batches, security, rbac, repo-tests, promotion, lifecycle, webhooks, search, platform, auth, compatibility, stress, resilience, mesh). With maxRunners=5 most of these serialise, making the full suite take ~45 minutes when they could finish much faster.

Upcoming #850 guest-access E2E work adds a second locked-down test namespace, which also benefits from the increased parallelism.

## Capacity check

Rocky cluster:
- 88 CPU allocatable, 164 GiB memory, 250 pod limit
- Each e2e runner requests 2 CPU / 4 GiB
- At max=20: 40 CPU / 80 GiB requested across all runners, well within cluster headroom

## Test Checklist

- [x] Unit tests added/updated (N/A, values file only)
- [x] Manually validated: values change is a single integer bump, no template rendering impact
- [x] No regressions in existing tests

## API Changes

- [x] N/A - no API changes