### PR TITLE
docs: add MIT LICENSE file (fixes #59)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brandon Geraci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -303,3 +303,7 @@ The deployment includes two open-source security scanning tools:
 | [artifact-keeper-web](https://github.com/artifact-keeper/artifact-keeper-web) | Web frontend (Next.js) |
 | [artifact-keeper-api](https://github.com/artifact-keeper/artifact-keeper-api) | OpenAPI spec + generated SDKs |
 | [artifact-keeper-site](https://github.com/artifact-keeper/artifact-keeper-site) | Documentation site |
+
+## License
+
+This repository is licensed under the [MIT License](LICENSE), matching the main [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper) project.


### PR DESCRIPTION
## Summary

Adds a top-level `LICENSE` file (MIT, copyright Brandon Geraci 2026) to resolve the licensing ambiguity @cazlo flagged in #59. The license matches the main `artifact-keeper` repository exactly.

Also adds a short "License" section in README.md pointing at the file so the intent is visible from the top-level docs.

Closes #59.

## Test Checklist
- [x] Unit tests added/updated (N/A - docs-only)
- [x] Manually verified LICENSE text matches artifact-keeper/LICENSE
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes