### PR TITLE
ci: skip SonarCloud Scan on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ak-ci-runners
+    # Skip on dependabot PRs: GitHub withholds secrets from dependabot
+    # runs for security reasons, so SONAR_TOKEN is empty and the scan
+    # always fails. SonarCloud provides no useful signal on dependency
+    # bumps anyway. Push events to main and human PRs still run it.
+    if: github.actor != 'dependabot[bot]'
     # SonarCloud Automatic Analysis may be enabled at the org level.
     # Until it is disabled in the SonarCloud UI (Administration > Analysis Method),
     # CI-based analysis will conflict and fail. Allow this job to fail gracefully


### PR DESCRIPTION
## Summary

GitHub withholds repo secrets from dependabot workflow runs for security reasons, so `SONAR_TOKEN` is always empty on those runs and the SonarCloud scanner exits with a failure. This blocks ~5 dependency-bump PRs from ever reaching green CI.

SonarCloud scans on dependency-bump PRs provide no real signal anyway (dependabot does not modify source code). The scan still runs on push events to `main` (where secrets are available) and on human-authored PRs.

Unblocks:
- #47 setup-python 5.3.0 → 6.2.0
- #49 chart-testing-action 2.6.1 → 2.8.0
- #52 setup-helm 4.3.1 → 5.0.0 (major, still needs real review)
- #58 sonarqube-scan-action 7.0.0 → 7.1.0

Longer-term alternative: add SONAR_TOKEN to the repo's Dependabot Secrets (Settings > Secrets and variables > Dependabot). That lets dependabot PRs see the token. This workflow change avoids that maintenance step.

## Test Checklist
- [x] Unit tests added/updated (N/A - workflow only)
- [x] Manually tested locally (YAML syntax + conditional expression verified)
- [x] No regressions: SonarCloud still runs on main pushes and human PRs

## API Changes
- [x] N/A - no API changes