### PR TITLE
feat(infra): artifact-keeper as docker.io pull-through cache for ARC runners

### DIFF
--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -3,7 +3,17 @@
 # Provides Docker capability so CI jobs can run docker-compose
 # based E2E test stacks (postgres + backend + test containers).
 #
+# DOCKER HUB PULL-THROUGH CACHE:
+# DinD here is configured with a registry-mirror pointing at the
+# in-cluster artifact-keeper registry-cache instance. Every docker.io
+# pull is routed through the cache, which solves the anonymous-pull
+# rate-limit problem we hit in CI. ghcr.io and other registries are
+# left untouched. The mirror config lives in the configmap
+# `dind-registry-mirror` (see e2e/dind-registry-mirror-configmap.yaml);
+# apply that BEFORE upgrading this release.
+#
 # Deployed via:
+#   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
 #   helm upgrade --install ak-e2e-runners \
 #     --namespace arc-runners \
 #     -f argocd/arc-e2e-runners-values.yaml \
@@ -59,6 +69,14 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          # Inject /etc/docker/daemon.json from the dind-registry-mirror
+          # configmap so dockerd routes docker.io pulls through the
+          # in-cluster artifact-keeper cache instead of hitting Docker
+          # Hub anonymously.
+          - name: dind-config
+            mountPath: /etc/docker/daemon.json
+            subPath: daemon.json
+            readOnly: true
     volumes:
       - name: work
         emptyDir: {}
@@ -66,3 +84,9 @@ template:
         emptyDir: {}
       - name: dind-externals
         emptyDir: {}
+      - name: dind-config
+        configMap:
+          name: dind-registry-mirror
+          items:
+            - key: daemon.json
+              path: daemon.json

--- a/argocd/registry-cache-application.yaml
+++ b/argocd/registry-cache-application.yaml
@@ -1,0 +1,62 @@
+# ArgoCD Application for the registry-cache artifact-keeper instance.
+#
+# Deploys an artifact-keeper instance pinned to a stable release (see
+# values-registry-cache.yaml) into the infra-registry-cache namespace.
+# This instance runs as a Docker Hub pull-through cache for the ARC
+# runners on the CI/CD runner cluster.
+#
+# Bootstrap order (run with kubectl context pointed at the runner cluster):
+#   1. Create the namespace and pre-stage the host directories.
+#        kubectl create namespace infra-registry-cache
+#        sudo mkdir -p /srv/ak-cache/{artifact-storage,postgres-data}
+#        sudo chown 1000:1000 /srv/ak-cache/artifact-storage
+#        sudo chown 999:999  /srv/ak-cache/postgres-data
+#   2. Apply the static PVs:
+#        kubectl apply -f e2e/registry-cache-pvs.yaml
+#   3. Apply this Application:
+#        kubectl apply -f argocd/registry-cache-application.yaml
+#   4. Wait for backend pod ready, then create the docker.io proxy repo
+#      via API (see docs/registry-cache.md).
+#
+# Updates: this Application is intentionally NOT registered with
+# image-updater. Bumps to backend.image.tag in values-registry-cache.yaml
+# go through a normal PR + manual sync after smoke testing.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: registry-cache
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: ak-infra
+    ak-infra-role: registry-mirror
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/artifact-keeper/artifact-keeper-iac
+    targetRevision: main
+    path: charts/artifact-keeper
+    helm:
+      releaseName: ak-cache
+      valueFiles:
+        - values.yaml
+        - values-registry-cache.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: infra-registry-cache
+  syncPolicy:
+    # Manual sync. We do NOT want autoSync here: every upgrade of the
+    # cache is a deliberate operator action with a smoke test attached.
+    automated: null
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+  ignoreDifferences:
+    # Static PVs we apply separately have a claimRef that ArgoCD doesn't
+    # know about; ignore the field on PVCs to avoid sync churn.
+    - group: ""
+      kind: PersistentVolumeClaim
+      jsonPointers:
+        - /spec/volumeName

--- a/charts/artifact-keeper/values-registry-cache.yaml
+++ b/charts/artifact-keeper/values-registry-cache.yaml
@@ -1,0 +1,101 @@
+# =============================================================================
+# Registry-cache overlay: artifact-keeper as a Docker Hub pull-through cache
+# =============================================================================
+#
+# Purpose: solve the "Docker Hub anonymous pull rate limit" problem on the
+# CI/CD runner cluster by routing all docker.io image pulls through an
+# in-cluster artifact-keeper instance configured as a remote/proxy repo.
+#
+# Stability ladder: this instance is intentionally pinned to a stable release
+# and updated MANUALLY only after smoke testing. Do NOT point it at :dev or
+# :latest, and do not enable image-updater for this Application. If the
+# cache breaks, every CI pull breaks.
+#
+# Storage: this overlay assumes static hostPath PVs already exist on the
+# runner host's persistent volume (typical clusters provision the default
+# `local-path` storage class on the root filesystem, which is too small
+# for a 100Gi+ image cache). The companion file
+# `e2e/registry-cache-pvs.yaml` provisions the static PVs.
+#
+# Bootstrap procedure: see docs/registry-cache.md.
+#
+# Failure mode: cache pod down → CI pulls fail. Mitigations:
+#   - Configure Docker Hub authentication on the runners as a secondary
+#     fallback (containerd's mirror config supports `endpoint` fallback).
+#   - Run two replicas of the cache once it has proven stable.
+# =============================================================================
+
+# Pin to a known-good stable release. Bump only after smoke testing.
+# Do NOT use 'dev' or 'latest' here. Document upgrades in CHANGELOG.
+backend:
+  image:
+    tag: "1.1.8"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  env:
+    RUST_LOG: "info"
+    ENVIRONMENT: "production"
+    AK_GUEST_ACCESS_ENABLED: "false"
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  persistence:
+    enabled: true
+    # Bound to the static PV ak-cache-artifact-storage-pv created by
+    # e2e/registry-cache-pvs.yaml (hostPath on the runner host's
+    # persistent volume).
+    size: 100Gi
+    storageClass: ""
+  autoscaling:
+    enabled: false
+  podDisruptionBudget:
+    enabled: false
+  service:
+    type: ClusterIP
+
+# The cache is a pure pull-through OCI proxy. No UI needed, and the web
+# image release schedule is independent from the backend's so the version
+# tags don't necessarily align (e.g. backend has 1.1.8 but web does not).
+# Keep web disabled to avoid that coupling. Operators who want the UI for
+# debugging can deploy a separate AK install or temporarily enable this.
+web:
+  enabled: false
+
+postgres:
+  enabled: true
+  persistence:
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# Pure pull-through cache: no scanners, no search, no extras.
+trivy:
+  enabled: false
+openscap:
+  enabled: false
+dependencyTrack:
+  enabled: false
+meilisearch:
+  enabled: false
+# Chart enables OpenSearch by default; explicitly disable it for the
+# cache. This instance does no full-text search.
+opensearch:
+  enabled: false
+
+# In-cluster only: no public ingress, no internet exposure.
+ingress:
+  enabled: false
+
+# Stable name across upgrades; service DNS becomes
+# `ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local`.
+fullnameOverride: "ak-cache"

--- a/docs/registry-cache.md
+++ b/docs/registry-cache.md
@@ -1,0 +1,174 @@
+# Registry-cache: artifact-keeper as a Docker Hub pull-through cache
+
+This document describes the dedicated artifact-keeper instance that runs
+on the CI/CD runner cluster as a Docker Hub pull-through cache for the
+ARC runners.
+
+## Why
+
+ARC runner pods are ephemeral: each runner's containerd cache disappears
+with the pod, and the cluster's single egress IP exhausts the anonymous
+Docker Hub pull quota quickly. We have a 45-format artifact registry
+sitting on the same cluster; using it as a pull-through cache for
+`docker.io` both removes the rate-limit pain and stress-tests the OCI
+proxy in a real load profile.
+
+## What it is and is not
+
+It is:
+
+- A dedicated artifact-keeper deployment in the `infra-registry-cache`
+  namespace.
+- A pinned, stable build (currently `1.1.8`). Manual upgrades only.
+- The mirror target configured in DinD's `daemon.json` for ARC runners.
+
+It is not:
+
+- A general-purpose artifact registry. The `infra-registry-cache`
+  namespace serves the cluster's CI plumbing only. Real artifact use
+  cases (npm, maven, etc.) belong on the production-tier instance.
+- HA. Single replica, single PVC, single node. HA is tracked separately.
+
+## Storage layout
+
+Static hostPath PVs on the runner host's persistent storage volume,
+matching the convention used by every other AK deployment on the
+cluster:
+
+```
+/srv/ak-cache/
+  artifact-storage/   # OCI blobs and manifests; bound to ak-cache-artifact-storage-pv
+  postgres-data/      # repo metadata, auth, etc.; bound to ak-cache-postgres-pv
+```
+
+`/srv/ak-cache/` is on the runner host's persistent-storage volume
+(typically a dedicated large mount, NOT the root filesystem). The
+default `local-path` storage class provisions on the root filesystem,
+which is too small for a cache that may grow to 100G+; static PVs
+avoid that. If your cluster's persistent-storage path differs, adjust
+the hostPath values in `e2e/registry-cache-pvs.yaml` accordingly.
+
+## Bootstrap
+
+```bash
+# All steps run with kubectl context pointed at the runner cluster.
+
+# 1. Pre-stage host directories (one time, on the runner host).
+#    Each component runs as its own uid: backend is 1000, postgres is 999.
+sudo mkdir -p /srv/ak-cache/{artifact-storage,postgres-data}
+sudo chown 1000:1000 /srv/ak-cache/artifact-storage
+sudo chown 999:999  /srv/ak-cache/postgres-data
+
+# 2. Create the namespace and apply the static PVs.
+kubectl create namespace infra-registry-cache
+kubectl apply -f e2e/registry-cache-pvs.yaml
+
+# 3. Apply the ArgoCD Application that owns the deployment.
+kubectl apply -f argocd/registry-cache-application.yaml
+
+# 4. Wait for the backend pod to be ready.
+kubectl -n infra-registry-cache rollout status deployment/ak-cache-artifact-keeper-backend
+```
+
+## Create the docker.io proxy repo
+
+The cache is just an artifact-keeper instance; we still need one
+remote/proxy Docker repo pointed at Docker Hub. Until we add a
+declarative bootstrap, do this once via the API.
+
+```bash
+# Resolve the in-cluster service URL.
+SVC=ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080
+kubectl -n infra-registry-cache exec deploy/ak-cache-artifact-keeper-backend -- \
+  cat /data/storage/admin.password
+
+# Login as admin (use the bootstrap password from above), then create the repo:
+TOKEN=$(curl -sf -X POST http://$SVC/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"<from above>"}' | jq -r .access_token)
+
+curl -sf -X POST http://$SVC/api/v1/repositories \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "key": "docker-hub-cache",
+        "name": "docker-hub-cache",
+        "format": "docker",
+        "repo_type": "remote",
+        "upstream_url": "https://registry-1.docker.io",
+        "is_public": true,
+        "allow_anonymous_access": true
+      }'
+```
+
+Anonymous read access is intentional: the cache must serve unauthenticated
+pulls because DinD has no credentials configured for this mirror.
+
+## Wire ARC runners to the cache
+
+```bash
+kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+
+helm upgrade --install ak-e2e-runners \
+  --namespace arc-runners \
+  -f argocd/arc-e2e-runners-values.yaml \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+```
+
+ARC runners scale to zero by default; the next CI job that spawns a runner
+picks up the new DinD config. To validate, watch a runner pod start and
+confirm `daemon.json` is mounted:
+
+```bash
+kubectl -n arc-runners logs -l app.kubernetes.io/name=actions-runner-controller -c dind | head
+```
+
+## Smoke test
+
+Run a one-off CI job that pulls `postgres:16-alpine` (or trigger the
+artifact-keeper coverage workflow). On the first pull the cache fetches
+from Docker Hub and stores blobs to
+`/srv/ak-cache/artifact-storage/`. On subsequent pulls
+(different runner pod, same image) the cache serves from local storage,
+with no Docker Hub egress.
+
+Verify cache hits in the cache backend logs:
+
+```bash
+kubectl -n infra-registry-cache logs deploy/ak-cache-artifact-keeper-backend | grep docker-hub-cache | tail
+```
+
+You should see GET requests with `cache=hit` (or equivalent) on the second
+and subsequent pulls.
+
+## Upgrade procedure
+
+The cache is pinned. To upgrade the version:
+
+1. Open a PR that bumps `backend.image.tag` and `web.image.tag` in
+   `charts/artifact-keeper/values-registry-cache.yaml` to the new stable
+   release. NEVER pick `:dev`, `:latest`, or an rc tag.
+2. After review and merge, sync the `registry-cache` ArgoCD Application
+   manually. Do not enable auto-sync.
+3. Run the smoke test above to confirm the new version still serves
+   pulls correctly.
+4. If anything regresses, revert the values change and resync. Cache
+   data on the PVC is unaffected by the version rollback.
+
+## Failure modes and mitigations
+
+| Failure | Symptom | Mitigation |
+|---|---|---|
+| Cache pod down | Every CI image pull fails | Run two replicas (HA, tracked separately). DinD's mirror config supports a fallback chain to authenticated Docker Hub. |
+| Cache PVC full | New pulls fail with disk-full | Bump PVC `capacity` in `e2e/registry-cache-pvs.yaml` (we have 1.6T headroom on /home). |
+| New stable release introduces OCI proxy regression | Pulls succeed but data is wrong | Roll back `backend.image.tag` and resync. Cache data unaffected. |
+
+## Tracked follow-up work
+
+- HA: run two replicas with a shared CSI volume (RWX). Today's PV is RWO
+  and pinned to one node.
+- Authenticated Docker Hub fallback in DinD's `daemon.json` for resilience
+  when the cache is down.
+- Declarative bootstrap of the `docker-hub-cache` repo so a fresh apply
+  doesn't need a manual API call.
+- Metrics: cache hit rate, evictions, bytes served from cache vs. upstream.

--- a/e2e/dind-registry-mirror-configmap.yaml
+++ b/e2e/dind-registry-mirror-configmap.yaml
@@ -1,0 +1,33 @@
+# Docker daemon config that points DinD at the in-cluster registry-cache
+# instance as a Docker Hub mirror.
+#
+# Apply BEFORE upgrading the ARC runners with the mirror-aware values:
+#   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+#
+# The mirror URL is the cache's backend service, which exposes the OCI
+# proxy repo `docker-hub-cache` (see docs/registry-cache.md for repo
+# creation).
+#
+# Note on `insecure-registries`: in-cluster traffic to the cache uses
+# plain HTTP. dockerd treats unknown schemes as TLS by default; we
+# whitelist this specific endpoint as insecure. There is no path on
+# this listener that exposes anything beyond the OCI registry, and the
+# service is ClusterIP-only (not reachable outside the cluster).
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dind-registry-mirror
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/component: registry-mirror
+data:
+  daemon.json: |
+    {
+      "registry-mirrors": [
+        "http://ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080"
+      ],
+      "insecure-registries": [
+        "ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080"
+      ]
+    }

--- a/e2e/registry-cache-pvs.yaml
+++ b/e2e/registry-cache-pvs.yaml
@@ -1,0 +1,65 @@
+# Static hostPath PVs for the registry-cache artifact-keeper instance.
+#
+# These bind to claims created by the helm chart with claimRef and live on
+# the runner host's large persistent volume rather than the default
+# local-path storageClass, which on this cluster provisions on the smaller
+# root filesystem.
+#
+# Layout: /srv/ak-cache/<volume-name>. /srv is the conventional location
+# for service data on Linux hosts; this path is owned by the cluster, not
+# any user account.
+#
+# Pre-create the directories with the correct ownership for each
+# component before applying:
+#   sudo mkdir -p /srv/ak-cache/{artifact-storage,postgres-data}
+#   sudo chown 1000:1000 /srv/ak-cache/artifact-storage   # backend uid
+#   sudo chown 999:999  /srv/ak-cache/postgres-data       # postgres uid (chart sets runAsUser: 999)
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ak-cache-artifact-storage-pv
+  labels:
+    app: backend
+    instance: ak-cache
+    volume: artifact-storage
+spec:
+  capacity:
+    # The actual cache. Sized for "many months of CI without eviction" against
+    # a Docker Hub mirror. Bump as growth dictates; the underlying /home
+    # volume is 1.8T so there is plenty of room.
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /srv/ak-cache/artifact-storage
+    type: DirectoryOrCreate
+  claimRef:
+    namespace: infra-registry-cache
+    name: ak-cache-storage
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ak-cache-postgres-pv
+  labels:
+    app: postgres
+    instance: ak-cache
+    volume: postgres-data
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /srv/ak-cache/postgres-data
+    type: DirectoryOrCreate
+  claimRef:
+    namespace: infra-registry-cache
+    name: postgres-data-ak-cache-postgres-0


### PR DESCRIPTION
## Summary

Solves the Docker Hub anonymous pull rate-limit failures we hit on the Rocky ARC runners (ephemeral pods, no shared image cache, single egress IP) by routing all `docker.io` pulls through an in-cluster artifact-keeper instance acting as a remote/proxy repo. Side benefit: stress-tests our own OCI proxy under real CI load.

## Files

| File | Purpose |
|---|---|
| `charts/artifact-keeper/values-registry-cache.yaml` | Helm overlay, pinned to `1.1.8`, scanners disabled, ClusterIP-only, `fullnameOverride: ak-cache` |
| `e2e/registry-cache-pvs.yaml` | Static hostPath PVs on `/home/khan/ak-data/ak-cache/` (1.6T free, not the 70G `/`) |
| `argocd/registry-cache-application.yaml` | ArgoCD Application, manual sync only, no image-updater |
| `e2e/dind-registry-mirror-configmap.yaml` | `daemon.json` with `registry-mirrors` pointing at the cache service |
| `argocd/arc-e2e-runners-values.yaml` (modified) | Mounts the configmap into DinD at `/etc/docker/daemon.json` |
| `docs/registry-cache.md` | Operator runbook: bootstrap, repo creation, smoke test, upgrade, failure modes |

## Key choices

- **Storage on `/home`, not `/`**: matches the existing AK deployment pattern on Rocky. Default `local-path` SC lands on `/` (38G free), inappropriate for a 100G cache.
- **`fullnameOverride: ak-cache`**: stable DNS across upgrades.
- **Manual sync, no auto-update**: cache is critical infrastructure; every upgrade is deliberate and smoke-tested.
- **ClusterIP only, no public ingress**: in-cluster traffic, plain HTTP, `insecure-registries` whitelisted in DinD config.

## Deployment plan

1. Pre-stage host directories on Rocky (`mkdir`, `chown`).
2. Create the `infra-registry-cache` namespace.
3. Apply the static PVs.
4. `helm install` the cache directly from this branch (ArgoCD adoption after merge).
5. Bootstrap-create the `docker-hub-cache` proxy repo via the API.
6. Apply the DinD mirror configmap and upgrade ARC runners.
7. Smoke-test by triggering a CI job that pulls a Docker Hub image; verify cache backend logs show the proxy fetching upstream and serving subsequent pulls from local storage.

I will be doing this initial deployment by hand over SSH on Rocky in the next step. ArgoCD takes over once this PR lands on main and `argocd/registry-cache-application.yaml` is applied.

## Test Plan

- [ ] Cache pod becomes Ready
- [ ] `docker-hub-cache` proxy repo created and reachable
- [ ] ARC runner DinD mounts the configmap
- [ ] First `docker pull postgres:16-alpine` from a CI runner succeeds and shows up in cache logs
- [ ] Second pull (different runner) shows a cache hit (no upstream egress)
- [ ] Coverage job on artifact-keeper#878 succeeds without rate-limit errors

## Follow-up work

- Declarative bootstrap of the proxy repo (small init Job in chart) so a fresh apply doesn't need a manual API call.
- Authenticated Docker Hub fallback in `daemon.json` for resilience when the cache is down.
- HA: two replicas with a shared CSI volume.
- Cache hit-rate metrics.