### PR TITLE
feat(release): chart-${appVersion} alias tag + RELEASING.md (#74)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -93,6 +93,7 @@ jobs:
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Run chart-releaser
+        id: cr
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
@@ -100,3 +101,54 @@ jobs:
           config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Tag chart-${appVersion} alias
+        # chart-releaser tags releases as "<chart-name>-<chart-version>" (for
+        # us, "artifact-keeper-<version>"). For users tracking which chart
+        # release pairs with which backend release, that name is opaque.
+        # Add a parallel "chart-<appVersion>" alias tag pointing to the
+        # same commit so users can run:
+        #   helm pull oci://... --version <appVersion>
+        # OR refer to chart-1.1.9 and know it pairs with backend 1.1.9.
+        # See iac issue #74 (Hardening Core Phase 1).
+        run: |
+          set -u
+          APP_VERSION=$(grep '^appVersion:' charts/artifact-keeper/Chart.yaml \
+            | awk '{print $2}' | tr -d '"')
+          CHART_VERSION=$(grep '^version:' charts/artifact-keeper/Chart.yaml \
+            | awk '{print $2}')
+
+          if [ -z "${APP_VERSION}" ] || [ -z "${CHART_VERSION}" ]; then
+            echo "::error::could not read appVersion or version from Chart.yaml"
+            exit 1
+          fi
+
+          ALIAS="chart-${APP_VERSION}"
+          ORIGIN_TAG="artifact-keeper-${CHART_VERSION}"
+
+          # If chart-releaser didn't actually create a release this run
+          # (skip_existing handled it), just exit cleanly.
+          if ! git rev-parse "${ORIGIN_TAG}" >/dev/null 2>&1; then
+            echo "Origin tag ${ORIGIN_TAG} does not exist; chart-releaser likely skipped this run. Nothing to alias."
+            exit 0
+          fi
+
+          # If the alias already exists pointing at the same commit, leave
+          # it alone. If it exists pointing at a DIFFERENT commit, fail
+          # loudly so the operator can decide whether to bump appVersion
+          # or replace the alias (don't silently overwrite history).
+          if git rev-parse "${ALIAS}" >/dev/null 2>&1; then
+            EXISTING=$(git rev-parse "${ALIAS}^{}")
+            EXPECTED=$(git rev-parse "${ORIGIN_TAG}^{}")
+            if [ "${EXISTING}" = "${EXPECTED}" ]; then
+              echo "Alias ${ALIAS} already points at ${EXPECTED}, nothing to do."
+              exit 0
+            else
+              echo "::error::Alias ${ALIAS} exists but points at ${EXISTING}, not the new ${ORIGIN_TAG} commit ${EXPECTED}. Bump appVersion in Chart.yaml or remove the stale alias."
+              exit 1
+            fi
+          fi
+
+          git tag "${ALIAS}" "${ORIGIN_TAG}"
+          git push origin "${ALIAS}"
+          echo "Created alias tag ${ALIAS} -> ${ORIGIN_TAG}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,96 @@
+# Releasing the Helm chart
+
+This document describes how chart releases relate to backend releases on the
+[`artifact-keeper`](https://github.com/artifact-keeper/artifact-keeper) repo,
+and how to cut a chart release that pairs cleanly with a specific backend
+version.
+
+Tracked under [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2)
+issue [#74](https://github.com/artifact-keeper/artifact-keeper-iac/issues/74).
+
+## Two version numbers, one chart
+
+The chart's `Chart.yaml` declares two distinct versions:
+
+- `version` — the chart's own SemVer. Bumps independently of the backend.
+- `appVersion` — the backend release this chart is intended to deploy.
+
+The chart-releaser action tags each release as `artifact-keeper-<version>`
+(e.g. `artifact-keeper-0.2.0`), which is the standard Helm-repository
+convention. To make it easy to find "the chart that pairs with backend
+1.1.9," every release also produces an alias tag named `chart-<appVersion>`
+pointing at the same commit (e.g. `chart-1.1.9`).
+
+Both tag names point at the same chart artifact:
+
+```
+artifact-keeper-0.2.0   <-- chart-releaser convention
+chart-1.1.9             <-- backend-pairing alias
+```
+
+## Cutting a release
+
+The flow assumes a backend release has just shipped.
+
+1. **Bump `appVersion`** in `charts/artifact-keeper/Chart.yaml` to the new
+   backend version (no `v` prefix), e.g. `appVersion: "1.1.9"`.
+2. **Bump `version`** in the same file according to chart-side SemVer rules.
+   Bump `patch` for value-only changes, `minor` for additive template
+   changes, `major` for breaking template changes.
+3. **Update default image tags** in `charts/artifact-keeper/values.yaml` for
+   `backend`, `web`, and `openscap` to the new backend version. Real
+   deployments should pin via their own values overlay, not rely on the
+   chart default, but the default is what new operators reach for first.
+4. **Verify image references resolve** by running `helm template` locally
+   against the updated values and confirming each `image: ...:tag` exists
+   on `ghcr.io` and `docker.io`. CI runs the same check on every PR via
+   the `verify-image-references` job in `helm-ci.yml`.
+5. **Open a PR** with the version bump. CI runs lint, kubeconform, image
+   verification, and the install-test against k3d.
+6. **Merge to `main`**. The `helm-release` workflow detects the version
+   change, packages the chart, and creates two tags:
+   - `artifact-keeper-<chart-version>` (e.g. `artifact-keeper-0.2.0`)
+   - `chart-<appVersion>` (e.g. `chart-1.1.9`)
+
+## Pulling a specific chart release
+
+Once the chart is published to the gh-pages Helm repo:
+
+```bash
+helm repo add artifact-keeper https://artifact-keeper.github.io/artifact-keeper-iac/
+helm repo update
+helm pull artifact-keeper/artifact-keeper --version <chart-version>
+```
+
+Or, by backend pairing, against the source repo directly:
+
+```bash
+git fetch --tags
+git checkout chart-1.1.9
+helm package charts/artifact-keeper/
+```
+
+## What goes wrong if `appVersion` is not bumped
+
+The release workflow's "Tag chart-${appVersion} alias" step refuses to
+silently overwrite an existing `chart-<X>` tag pointing at a different
+commit. If you forget to bump `appVersion` between releases, the alias
+step fails with a clear error and the chart-releaser tag still gets
+created (so the chart is published), but the backend-pairing alias is
+left alone. Fix by either:
+
+- Bumping `appVersion` to the actually-new backend version (most cases), or
+- Manually removing the stale alias tag and re-running the release.
+
+## What about backend `v1.1.9-rc.1`?
+
+The same convention applies. `appVersion: "1.1.9-rc.1"` produces alias
+`chart-1.1.9-rc.1`. Pre-release backend versions get pre-release chart
+tags by default.
+
+## Future automation
+
+The current process is manual: an operator opens a PR with the version
+bumps when a backend release ships. A future workflow can listen for a
+`repository_dispatch` event from the backend release pipeline and open
+the bump PR automatically. Tracked separately.


### PR DESCRIPTION
Closes #74.

## Summary

Two changes, one PR:

**1. Workflow:** after `chart-releaser-action` runs, additionally tag the chart release commit with `chart-<appVersion>` (e.g. `chart-1.1.9`). The chart-releaser tag (`artifact-keeper-<chart-version>`) follows the Helm convention and stays in place; the new alias makes it easy to find the chart release that pairs with a specific backend release.

**2. Documentation:** new `RELEASING.md` at the repo root explaining:
- The two version numbers (`version` vs `appVersion`) and how they relate.
- The per-release operator checklist.
- How to pull a chart release by backend pairing.
- What the alias-collision error looks like (the workflow refuses to silently overwrite).
- A note that fully-automated bump-on-backend-release is a future follow-up.

## Why

v1.1.8 shipped without a clear "this chart pairs with backend 1.1.8" tag. Operators had to read the chart's `appVersion` field manually to know which backend version a given chart release matched. With `chart-<appVersion>` aliases, every chart release is reachable by both names:

```
artifact-keeper-0.2.0   <-- chart-releaser convention
chart-1.1.9             <-- backend-pairing alias
```

## Pairs with

[#76](https://github.com/artifact-keeper/artifact-keeper-iac/pull/76) — the chart-side image-reference gate. Together they give the chart release flow teeth: the gate refuses to merge a chart change that references missing images; the alias tag makes the resulting chart easy to find by backend pairing.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses `helm-release.yml` cleanly
- [x] `RELEASING.md` renders correctly on the GitHub repo view
- [ ] After merge, next chart release should produce both tag names; verify by running the workflow and checking `git tag -l 'chart-*'` on the repo

## API Changes

- [x] N/A — workflow + docs

## Hardening Core

Phase 1 of [Hardening Core](https://github.com/orgs/artifact-keeper/projects/2).