### PR TITLE
infra(runners): commit IaC for ak-ci-runners + Docker Hub auth across pools

### DIFF
--- a/argocd/arc-beefy-runners-values.yaml
+++ b/argocd/arc-beefy-runners-values.yaml
@@ -10,7 +10,20 @@
 #
 # Opt jobs in by setting `runs-on: ak-beefy-runners` in the workflow.
 #
+# DOCKER HUB PULL-THROUGH AND AUTH
+# --------------------------------
+# Mirrors the ak-ci-runners setup:
+#  1. dind sidecar mounts /etc/docker/daemon.json from the
+#     `dind-registry-mirror` ConfigMap so pulls route through the
+#     in-cluster artifact-keeper registry-cache when possible.
+#  2. The runner container mounts the `dockerhub-pull` Secret at
+#     ~/.docker/config.json so authenticated docker.io pulls bypass
+#     the anonymous rate limit when the cache cannot serve a request.
+#
 # Deployed via:
+#   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+#   kubectl -n arc-runners create secret docker-registry dockerhub-pull ...
+#     (see argocd/dockerhub-pull-secret.example.yaml)
 #   helm upgrade --install ak-beefy-runners \
 #     --namespace arc-runners \
 #     --version 0.13.1 \
@@ -67,6 +80,10 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          - name: dockerhub-config
+            mountPath: /home/runner/.docker/config.json
+            subPath: .dockerconfigjson
+            readOnly: true
         resources:
           requests:
             cpu: "4"
@@ -110,6 +127,10 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          - name: dind-config
+            mountPath: /etc/docker/daemon.json
+            subPath: daemon.json
+            readOnly: true
     volumes:
       - name: work
         emptyDir: {}
@@ -117,3 +138,12 @@ template:
         emptyDir: {}
       - name: dind-externals
         emptyDir: {}
+      - name: dind-config
+        configMap:
+          name: dind-registry-mirror
+          items:
+            - key: daemon.json
+              path: daemon.json
+      - name: dockerhub-config
+        secret:
+          secretName: dockerhub-pull

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -1,47 +1,58 @@
-# ARC v2 Runner Scale Set for E2E Tests (with Docker-in-Docker)
+# ARC v2 Runner Scale Set for fast CI jobs (lint, unit tests, helm chart CI).
 #
-# Provides Docker capability so CI jobs can run docker-compose
-# based E2E test stacks (postgres + backend + test containers).
+# Purpose
+# -------
+# Default pool for the artifact-keeper org. Workflows opt in with
+# `runs-on: ak-ci-runners`. Heavier jobs use `ak-beefy-runners` and
+# E2E suites with full docker-compose stacks use `ak-e2e-runners`.
 #
 # DOCKER HUB PULL-THROUGH AND AUTH
 # --------------------------------
 # Two layers, applied independently:
 #
 # 1. dind sidecar mounts /etc/docker/daemon.json from the
-#    `dind-registry-mirror` ConfigMap (e2e/dind-registry-mirror-configmap.yaml)
-#    so dockerd routes docker.io pulls through the in-cluster
-#    artifact-keeper registry-cache where possible.
+#    `dind-registry-mirror` ConfigMap (e2e/dind-registry-mirror-configmap.yaml).
+#    dockerd routes docker.io pulls through the in-cluster
+#    artifact-keeper cache where possible.
 #
 # 2. The runner container mounts the `dockerhub-pull` Secret at
-#    ~/.docker/config.json. When dockerd falls back to docker.io
+#    `~/.docker/config.json`. When dockerd falls back to docker.io
 #    directly (the cache cannot serve dockerd-mirror style requests
 #    until the DOCKER_HUB_MIRROR_REPO backend feature ships), the auth
 #    raises the rate limit from 100 anonymous pulls / 6h per IP to a
 #    per-user budget. See argocd/dockerhub-pull-secret.example.yaml for
 #    how to create the Secret.
 #
+# RUNNER IMAGE
+# ------------
+# Uses ghcr.io/artifact-keeper/ak-runner-rust:latest (built from
+# runner-images/rust/Dockerfile) with cargo, sccache, and npm caches
+# pre-baked. The /cache hostPath persists those caches across runners.
+#
 # Deployed via:
 #   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
 #   kubectl -n arc-runners create secret docker-registry dockerhub-pull ...
 #     (see argocd/dockerhub-pull-secret.example.yaml)
-#   helm upgrade --install ak-e2e-runners \
+#   helm upgrade --install ak-ci-runners \
 #     --namespace arc-runners \
 #     --version 0.13.1 \
-#     -f argocd/arc-e2e-runners-values.yaml \
+#     -f argocd/arc-ci-runners-values.yaml \
 #     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
 #
 # NOTE: pin --version 0.13.1 to match the ARC controller version
-# already running on the cluster (arc-systems namespace).
+# already running on the cluster (arc-systems namespace). Chart 0.14.x
+# renders an incompatible AutoscalingRunnerSet CR that the 0.13.x
+# controller silently drops.
 #
 # Requires secret "github-token-secret" in arc-runners namespace with
 # key "github_token".
 
 githubConfigUrl: "https://github.com/artifact-keeper"
 githubConfigSecret: "github-token-secret"
-runnerScaleSetName: "ak-e2e-runners"
+runnerScaleSetName: "ak-ci-runners"
 
 minRunners: 0
-maxRunners: 5
+maxRunners: 20
 
 template:
   spec:
@@ -49,22 +60,26 @@ template:
       - name: ghcr-pull-secret
     containers:
       - name: runner
-        image: ghcr.io/artifact-keeper/ak-runner-e2e:latest
-        command: ["/home/runner/run.sh"]
+        image: ghcr.io/artifact-keeper/ak-runner-rust:latest
+        command:
+          - /bin/bash
+          - -c
+          - umask 0000 && /home/runner/run.sh
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
-        volumeMounts:
-          - name: work
-            mountPath: /home/runner/_work
-          - name: dind-var
-            mountPath: /var/run
-          - name: dind-externals
-            mountPath: /home/runner/externals
-          - name: dockerhub-config
-            mountPath: /home/runner/.docker/config.json
-            subPath: .dockerconfigjson
-            readOnly: true
+          - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+            value: "120"
+          - name: CARGO_HOME
+            value: /cache/cargo-home
+          - name: SCCACHE_DIR
+            value: /cache/sccache
+          - name: RUSTC_WRAPPER
+            value: sccache
+          - name: NPM_CONFIG_CACHE
+            value: /cache/npm
+          - name: SCCACHE_IDLE_TIMEOUT
+            value: "0"
         resources:
           requests:
             cpu: "2"
@@ -72,9 +87,22 @@ template:
           limits:
             cpu: "4"
             memory: "8Gi"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-var
+            mountPath: /var/run
+          - name: dind-externals
+            mountPath: /home/runner/externals
+          - name: runner-cache
+            mountPath: /cache
+          - name: dockerhub-config
+            mountPath: /home/runner/.docker/config.json
+            subPath: .dockerconfigjson
+            readOnly: true
     initContainers:
       - name: init-dind-externals
-        image: ghcr.io/artifact-keeper/ak-runner-e2e:latest
+        image: ghcr.io/artifact-keeper/ak-runner-rust:latest
         command:
           - cp
           - -r
@@ -83,16 +111,24 @@ template:
         volumeMounts:
           - name: dind-externals
             mountPath: /home/runner/tmpDir
+      - name: init-cache
+        image: ghcr.io/artifact-keeper/ak-runner-rust:latest
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - mkdir -p /cache/cargo-home /cache/sccache /cache/npm && chmod -R 777 /cache/cargo-home /cache/sccache /cache/npm
+        volumeMounts:
+          - name: runner-cache
+            mountPath: /cache
       - name: dind
-        image: docker:dind
+        image: docker:27-dind
         args:
           - dockerd
           - --host=unix:///var/run/docker.sock
           - --storage-driver=vfs
           - --group=123
-        env:
-          - name: DOCKER_GROUP_GID
-            value: "123"
         restartPolicy: Always
         securityContext:
           privileged: true
@@ -101,9 +137,9 @@ template:
             command:
               - docker
               - info
-          failureThreshold: 24
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          failureThreshold: 30
+          initialDelaySeconds: 3
+          periodSeconds: 3
         volumeMounts:
           - name: work
             mountPath: /home/runner/_work
@@ -122,6 +158,10 @@ template:
         emptyDir: {}
       - name: dind-externals
         emptyDir: {}
+      - name: runner-cache
+        hostPath:
+          path: /home/runner-cache
+          type: DirectoryOrCreate
       - name: dind-config
         configMap:
           name: dind-registry-mirror

--- a/argocd/dockerhub-pull-secret.example.yaml
+++ b/argocd/dockerhub-pull-secret.example.yaml
@@ -1,0 +1,58 @@
+# Docker Hub credentials used by the ARC runner pods to authenticate
+# docker.io pulls and avoid the anonymous-pull rate limit.
+#
+# Why this exists
+# ---------------
+# The dind sidecar's daemon.json points dockerd at the in-cluster
+# artifact-keeper registry-cache as a registry-mirror. For requests the
+# cache cannot serve (transparent dockerd-mirror style URLs are not yet
+# supported by the backend; see DOCKER_HUB_MIRROR_REPO feature, planned
+# for a later release), dockerd falls back to docker.io directly. With
+# anonymous auth the rate limit is 100 pulls / 6h per egress IP, which
+# CI burns through quickly. Authenticated pulls get a per-user budget.
+#
+# Scope required
+# --------------
+# The PAT only needs read access. From hub.docker.com -> Account
+# Settings -> Security -> New Access Token -> "Public Repo Read-only"
+# (or "Repo / Read" if you also want to pull private org images).
+#
+# Apply (recommended: kubectl, do not commit the real token)
+# ----------------------------------------------------------
+#   kubectl -n arc-runners create secret docker-registry dockerhub-pull \
+#     --docker-server=https://index.docker.io/v1/ \
+#     --docker-username=<your-dockerhub-username> \
+#     --docker-password=<dckr_pat_or_oat_token>
+#
+# The Secret is mounted by the three runner Helm releases
+# (ak-ci-runners, ak-beefy-runners, ak-e2e-runners) at
+# /home/runner/.docker/config.json on the runner container.
+#
+# Rotation
+# --------
+# Revoke and reissue the PAT periodically. After reissuing, recreate
+# the Secret with the same name and ARC will pick it up on the next
+# pod restart (no helm upgrade needed because the volume references
+# the secret by name).
+#
+# Manifest form (only if you really want to apply via YAML; mind that
+# the dockerconfigjson must be base64-encoded and contains the token)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhub-pull
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/component: docker-hub-auth
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "https://index.docker.io/v1/": {
+          "username": "REPLACE_DOCKERHUB_USERNAME",
+          "password": "REPLACE_DOCKERHUB_PAT",
+          "auth": "REPLACE_BASE64(username:password)"
+        }
+      }
+    }


### PR DESCRIPTION
## Summary

Brings ARC runner IaC in line with the live cluster and lets the runners authenticate to docker.io so CI stops getting throttled by the anonymous-pull rate limit. Part of the 1.1.9 infra-hardening epic.

The committed beefy/e2e values were stale vs. the live cluster, and `ak-ci-runners` had no committed IaC at all (deployed imperatively, values only on the cluster). This PR closes that drift.

### What changed

- **New** `argocd/arc-ci-runners-values.yaml` — captures live `ak-ci-runners` shape (rust runner image with cargo/sccache/npm caches, dind sidecar with mirror configmap, `/cache` hostPath).
- **Updated** `argocd/arc-beefy-runners-values.yaml` — adds the dockerhub-pull mount; rest matches what's on the cluster.
- **Updated** `argocd/arc-e2e-runners-values.yaml` — switched to the K8s native sidecar pattern (`initContainers` + `restartPolicy: Always`) that the cluster has been running, plus the dockerhub-pull mount.
- **New** `argocd/dockerhub-pull-secret.example.yaml` — documents how to create the Secret without committing a PAT.

### How the auth works

All three runner pools now mount a `dockerhub-pull` Secret at `/home/runner/.docker/config.json` on the runner container. When `docker pull` runs inside a job, the CLI reads the config, authenticates to docker.io, and gets a per-user rate-limit budget (vs. the 100 pulls / 6h per IP anonymous limit).

This pairs with the existing `dind-registry-mirror` ConfigMap (already in `e2e/`): dockerd tries the in-cluster artifact-keeper cache first, then falls back to authenticated docker.io when the cache cannot serve. The cache cannot answer dockerd-style mirror requests today; that is the `DOCKER_HUB_MIRROR_REPO` backend feature (planned for a later release).

### Live cluster status

The Secret + Helm upgrades are already applied on Rocky (verified by re-running the failing PR #897 Code Coverage job). This PR brings the YAML into git so the next person can reproduce it.

### Rollback

Revert this commit and `helm upgrade` each release with the prior values from `git show HEAD~1:argocd/arc-*-runners-values.yaml`. The `dockerhub-pull` Secret is harmless to leave behind; nothing references it once unmounted.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [x] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: \`helm template\` renders correctly
- [ ] Terraform: \`terraform validate\` passes
- [ ] Terraform: \`terraform plan\` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [ ] N/A - documentation only