### PR TITLE
fix(runners): writable ~/.docker/config.json so docker login works (iac#83)

### DIFF
--- a/argocd/arc-beefy-runners-values.yaml
+++ b/argocd/arc-beefy-runners-values.yaml
@@ -80,10 +80,8 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
-          - name: dockerhub-config
-            mountPath: /home/runner/.docker/config.json
-            subPath: .dockerconfigjson
-            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
         resources:
           requests:
             cpu: "4"
@@ -92,6 +90,35 @@ template:
             cpu: "8"
             memory: "16Gi"
     initContainers:
+      - name: init-dockerhub-creds
+        # Copy the dockerhub-pull Secret's dockerconfigjson into a
+        # writable emptyDir mounted at /home/runner/.docker. This
+        # gives docker pulls authenticated rate limits AND leaves
+        # ~/.docker/config.json writable for subsequent `docker login`
+        # calls (e.g. `docker login ghcr.io` in workflows). The earlier
+        # readOnly: true subPath mount blocked those writes (iac#83).
+        image: busybox:1.36.1
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - |
+            mkdir -p /home/runner/.docker
+            if [ -f /secret/.dockerconfigjson ]; then
+              cp /secret/.dockerconfigjson /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker/config.json
+              chmod 600 /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker
+            else
+              echo "WARN: /secret/.dockerconfigjson not found; dockerhub-pull Secret may not be wired"
+            fi
+        volumeMounts:
+          - name: dockerhub-secret
+            mountPath: /secret
+            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
       - name: init-dind-externals
         image: ghcr.io/actions/actions-runner:latest
         command:
@@ -144,6 +171,8 @@ template:
           items:
             - key: daemon.json
               path: daemon.json
-      - name: dockerhub-config
+      - name: dockerhub-secret
         secret:
           secretName: dockerhub-pull
+      - name: docker-config-dir
+        emptyDir: {}

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -96,11 +96,38 @@ template:
             mountPath: /home/runner/externals
           - name: runner-cache
             mountPath: /cache
-          - name: dockerhub-config
-            mountPath: /home/runner/.docker/config.json
-            subPath: .dockerconfigjson
-            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
     initContainers:
+      - name: init-dockerhub-creds
+        # Copy the dockerhub-pull Secret's dockerconfigjson into a
+        # writable emptyDir mounted at /home/runner/.docker. This
+        # gives docker pulls authenticated rate limits AND leaves
+        # ~/.docker/config.json writable for subsequent `docker login`
+        # calls (e.g. `docker login ghcr.io` in workflows). The earlier
+        # readOnly: true subPath mount blocked those writes (iac#83).
+        image: busybox:1.36.1
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - |
+            mkdir -p /home/runner/.docker
+            if [ -f /secret/.dockerconfigjson ]; then
+              cp /secret/.dockerconfigjson /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker/config.json
+              chmod 600 /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker
+            else
+              echo "WARN: /secret/.dockerconfigjson not found; dockerhub-pull Secret may not be wired"
+            fi
+        volumeMounts:
+          - name: dockerhub-secret
+            mountPath: /secret
+            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
       - name: init-dind-externals
         image: ghcr.io/artifact-keeper/ak-runner-rust:latest
         command:
@@ -168,6 +195,8 @@ template:
           items:
             - key: daemon.json
               path: daemon.json
-      - name: dockerhub-config
+      - name: dockerhub-secret
         secret:
           secretName: dockerhub-pull
+      - name: docker-config-dir
+        emptyDir: {}

--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -61,10 +61,8 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
-          - name: dockerhub-config
-            mountPath: /home/runner/.docker/config.json
-            subPath: .dockerconfigjson
-            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
         resources:
           requests:
             cpu: "2"
@@ -73,6 +71,35 @@ template:
             cpu: "4"
             memory: "8Gi"
     initContainers:
+      - name: init-dockerhub-creds
+        # Copy the dockerhub-pull Secret's dockerconfigjson into a
+        # writable emptyDir mounted at /home/runner/.docker. This
+        # gives docker pulls authenticated rate limits AND leaves
+        # ~/.docker/config.json writable for subsequent `docker login`
+        # calls (e.g. `docker login ghcr.io` in workflows). The earlier
+        # readOnly: true subPath mount blocked those writes (iac#83).
+        image: busybox:1.36.1
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - |
+            mkdir -p /home/runner/.docker
+            if [ -f /secret/.dockerconfigjson ]; then
+              cp /secret/.dockerconfigjson /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker/config.json
+              chmod 600 /home/runner/.docker/config.json
+              chown 1001:1001 /home/runner/.docker
+            else
+              echo "WARN: /secret/.dockerconfigjson not found; dockerhub-pull Secret may not be wired"
+            fi
+        volumeMounts:
+          - name: dockerhub-secret
+            mountPath: /secret
+            readOnly: true
+          - name: docker-config-dir
+            mountPath: /home/runner/.docker
       - name: init-dind-externals
         image: ghcr.io/artifact-keeper/ak-runner-e2e:latest
         command:
@@ -128,6 +155,8 @@ template:
           items:
             - key: daemon.json
               path: daemon.json
-      - name: dockerhub-config
+      - name: dockerhub-secret
         secret:
           secretName: dockerhub-pull
+      - name: docker-config-dir
+        emptyDir: {}


### PR DESCRIPTION
## Summary

Closes iac#83 (regression I introduced in PR #79 last week).

The `dockerhub-pull` Secret was mounted as a readOnly subPath file at `/home/runner/.docker/config.json` to give docker pulls authenticated rate limits. Side effect: any workflow that subsequently runs `docker login <other-registry>` fails because docker tries to atomically rewrite the merged config and gets "permission denied".

Concrete failure: artifact-keeper's Smoke E2E job runs `docker login ghcr.io` and has been failing since 2026-04-26 with `permission denied` on the config file's temp name. Backport PRs (#891, #899, #900) inherit the failure on every run.

## Fix (Strategy A from iac#83)

Replace the read-only secret mount with an initContainer that copies the dockerhub-pull dockerconfigjson into a writable emptyDir at `/home/runner/.docker`. Subsequent `docker login` calls can then atomically rewrite the merged config.

Applied identically to all three runner pools (`arc-ci-runners`, `arc-beefy-runners`, `arc-e2e-runners`):
- New initContainer `init-dockerhub-creds`: copies, chowns to runner uid 1001, chmods 600.
- Runner container's volumeMount: directory mount at `/home/runner/.docker` instead of the readOnly subPath file.
- Volumes: split into `dockerhub-secret` (used only by init) + `docker-config-dir` (writable emptyDir shared between init and runner).

## Verification

Live cluster has already been helm-upgraded with these values. Smoke E2E re-runs on the v1.1.9 backports should now pass.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly -- N/A
- [x] Manually verified on staging cluster (live cluster already running this config)
- [x] Rollback strategy documented (revert the commit, re-apply old values)

## Infrastructure
- [x] Helm: \`helm template\` renders correctly
- [ ] Terraform: \`terraform validate\` passes -- N/A
- [ ] Terraform: \`terraform plan\` shows expected changes -- N/A
- [ ] ArgoCD: Application manifests are valid -- N/A (helm-managed)
- [ ] N/A - documentation only