### PR TITLE
feat(values): document proxy stampede protection knobs

### DIFF
--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -205,6 +205,23 @@ backend:
     # RATE_LIMIT_EXEMPT_USERNAMES: ""
     # RATE_LIMIT_EXEMPT_SERVICE_ACCOUNTS: "false"
 
+    # -- Proxy Stampede Protection (remote/proxy repository upstream fetch limiter)
+    # Bounds peak concurrent in-flight upstream fetches across all remote
+    # repos. Prevents thundering-herd against upstream registries (PyPI,
+    # Maven Central, npm, Docker Hub, etc.) when many clients race for the
+    # same uncached artifact. When the queue saturates, requests return
+    # 503 Service Unavailable so clients back off rather than block.
+    #
+    # Operator dashboards: ak_proxy_upstream_inflight (gauge),
+    # ak_proxy_queue_full_total (counter), ak_proxy_queue_wait_seconds
+    # (histogram). A sustained queue_full rate signals undersized cap.
+    #
+    # PROXY_MAX_CONCURRENT_FETCHES: "20"   # Concurrent upstream fetch cap (default: 20).
+    #                                      # Set to "0" to DISABLE the limiter
+    #                                      # entirely (kill switch). Logs a
+    #                                      # startup warning when disabled.
+    # PROXY_QUEUE_TIMEOUT_SECS: "10"       # Per-request queue wait budget (default: 10).
+
     # -- Security Scanning
     # OPENSCAP_PROFILE: "xccdf_org.ssgproject.content_profile_standard"
     # GITHUB_TOKEN: ""


### PR DESCRIPTION
## Summary

Companion to artifact-keeper PR #942 (proxy stampede semaphore). Adds commented `PROXY_MAX_CONCURRENT_FETCHES` and `PROXY_QUEUE_TIMEOUT_SECS` to the `backend.env` block in `values.yaml` so operators can discover the new knobs.

Both vars fall through the existing `backend.env` range loop in `templates/backend-deployment.yaml`, so no template change is needed — this PR is documentation of the new operator surface only.

Defaults match the backend (20 concurrent fetches, 10s queue timeout). Setting `MAX_CONCURRENT_FETCHES: "0"` disables the limiter entirely (kill switch for emergency rollback); the backend logs a startup warning when disabled.

Closes the operator-discoverability gap raised in the round-1 review of PR #942.

## Test Checklist
- [x] Helm template renders without errors (`helm lint charts/artifact-keeper/` clean; `helm template` succeeds with required `--set secrets.jwtSecret=x --set postgres.auth.password=y` placeholders)
- [ ] Terraform validates/plans cleanly — N/A, no Terraform touched
- [ ] Manually verified on staging cluster (if applicable) — N/A, this is a documentation-only YAML comment block; defaults take effect when env vars are absent
- [x] Rollback strategy documented — revert this PR; backend defaults from `Config::default()` apply unchanged

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes — N/A
- [ ] Terraform: `terraform plan` shows expected changes — N/A
- [ ] ArgoCD: Application manifests are valid — N/A, no Application manifests touched
- [x] N/A - documentation only (commented env-var block; takes effect only when an operator uncomments and sets values)