### PR TITLE
fix(dind): correct ak-cache service name + wire mirror-mode env var

### DIFF
--- a/charts/artifact-keeper/values-registry-cache.yaml
+++ b/charts/artifact-keeper/values-registry-cache.yaml
@@ -36,6 +36,15 @@ backend:
     RUST_LOG: "info"
     ENVIRONMENT: "production"
     AK_GUEST_ACCESS_ENABLED: "false"
+    # Mirror-mode fallback for Docker daemon registry-mirrors. When a
+    # request arrives at `/v2/<image>/...` (no AK repo prefix -- the path
+    # layout dockerd's `registry-mirrors` produces) and the literal
+    # repo_key lookup misses, the backend re-resolves through the named
+    # proxy repo with the full image_name as the upstream image path.
+    # Requires the `docker-hub-cache` proxy repo to exist (see
+    # docs/registry-cache.md). Implemented in artifact-keeper PR #944
+    # (release/1.1.x) / PR #945 (main).
+    AK_DEFAULT_DOCKER_MIRROR_REPO: "docker-hub-cache"
   resources:
     requests:
       cpu: 250m
@@ -97,5 +106,9 @@ ingress:
   enabled: false
 
 # Stable name across upgrades; service DNS becomes
-# `ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local`.
+# `ak-cache-backend.infra-registry-cache.svc.cluster.local`.
+# (The chart's helper expands `<fullnameOverride>-<component>`, NOT
+# `<fullnameOverride>-artifact-keeper-<component>` -- earlier comments here
+# and in `e2e/dind-registry-mirror-configmap.yaml` had the wrong DNS name,
+# silently breaking dockerd's `registry-mirrors` config.)
 fullnameOverride: "ak-cache"

--- a/docs/registry-cache.md
+++ b/docs/registry-cache.md
@@ -67,7 +67,7 @@ kubectl apply -f e2e/registry-cache-pvs.yaml
 kubectl apply -f argocd/registry-cache-application.yaml
 
 # 4. Wait for the backend pod to be ready.
-kubectl -n infra-registry-cache rollout status deployment/ak-cache-artifact-keeper-backend
+kubectl -n infra-registry-cache rollout status deployment/ak-cache-backend
 ```
 
 ## Create the docker.io proxy repo
@@ -78,8 +78,8 @@ declarative bootstrap, do this once via the API.
 
 ```bash
 # Resolve the in-cluster service URL.
-SVC=ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080
-kubectl -n infra-registry-cache exec deploy/ak-cache-artifact-keeper-backend -- \
+SVC=ak-cache-backend.infra-registry-cache.svc.cluster.local:8080
+kubectl -n infra-registry-cache exec deploy/ak-cache-backend -- \
   cat /data/storage/admin.password
 
 # Login as admin (use the bootstrap password from above), then create the repo:
@@ -135,7 +135,7 @@ with no Docker Hub egress.
 Verify cache hits in the cache backend logs:
 
 ```bash
-kubectl -n infra-registry-cache logs deploy/ak-cache-artifact-keeper-backend | grep docker-hub-cache | tail
+kubectl -n infra-registry-cache logs deploy/ak-cache-backend | grep docker-hub-cache | tail
 ```
 
 You should see GET requests with `cache=hit` (or equivalent) on the second

--- a/e2e/dind-registry-mirror-configmap.yaml
+++ b/e2e/dind-registry-mirror-configmap.yaml
@@ -6,7 +6,11 @@
 #
 # The mirror URL is the cache's backend service, which exposes the OCI
 # proxy repo `docker-hub-cache` (see docs/registry-cache.md for repo
-# creation).
+# creation). Mirror-mode routing in the AK backend (artifact-keeper PR
+# #944 / #945) requires `AK_DEFAULT_DOCKER_MIRROR_REPO=docker-hub-cache`
+# on the cache deployment so prefix-less `/v2/<image>/...` requests
+# (the path layout dockerd's `registry-mirrors` produces) get routed
+# through the proxy repo.
 #
 # Note on `insecure-registries`: in-cluster traffic uses plain HTTP.
 # dockerd treats unknown schemes as TLS by default; we whitelist the
@@ -18,7 +22,7 @@
 # in-cluster Service ClusterIP, including:
 #
 #   - The dogfood Docker Hub cache at
-#     ak-cache-artifact-keeper-backend.infra-registry-cache.svc...:8080
+#     ak-cache-backend.infra-registry-cache.svc.cluster.local:8080
 #   - Ephemeral test backends at
 #     artifact-keeper-backend.test-${RUN_ID}.svc...:8080 (used by the
 #     format-test docker native client gates -- artifact-keeper-test#52)
@@ -38,10 +42,10 @@ data:
   daemon.json: |
     {
       "registry-mirrors": [
-        "http://ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080"
+        "http://ak-cache-backend.infra-registry-cache.svc.cluster.local:8080"
       ],
       "insecure-registries": [
-        "ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080",
+        "ak-cache-backend.infra-registry-cache.svc.cluster.local:8080",
         "10.96.0.0/12"
       ]
     }


### PR DESCRIPTION
## Summary

Two stacked bugs were silently making dockerd's `registry-mirrors` config a no-op, sending every CI service-container pull through the cluster's egress IP and exhausting Docker Hub's anonymous pull limit (`toomanyrequests`).

**Bug 1 (this repo): wrong service DNS in the dind configmap.**
The `dind-registry-mirror` configmap pointed at `ak-cache-artifact-keeper-backend.infra-registry-cache.svc.cluster.local:8080` but that name does not exist and never did. The chart's fullname helper expands `<fullnameOverride>-<component>`, NOT `<fullnameOverride>-artifact-keeper-<component>`, so with `fullnameOverride: "ak-cache"` the actual service is `ak-cache-backend`. The misspelled DNS resolved NXDOMAIN, dockerd silently fell back to direct Docker Hub pulls, and operators (correctly) thought they had a working mirror — until Docker Hub's rate limit hit.

Verified live via `nslookup` from the dind container: `ak-cache-artifact-keeper-backend...` → NXDOMAIN; `ak-cache-backend...` → resolves to 10.103.183.77.

**Bug 2 (artifact-keeper backend, fixed in PR #944 / #945): `/v2/` router required a repo prefix.**
Even with the right DNS, the AK backend's `/v2/` route required `/v2/<repo-key>/<image>/...`. Docker daemon's `registry-mirrors` produces `/v2/<image>/...` with NO prefix, so `repo_key="library"` 404'd and dockerd fell back to Docker Hub. Fixed by an opt-in mirror-mode fallback in `resolve_repo` keyed on `AK_DEFAULT_DOCKER_MIRROR_REPO`.

## Changes

| File | Change |
|---|---|
| `e2e/dind-registry-mirror-configmap.yaml` | Replace `ak-cache-artifact-keeper-backend` with `ak-cache-backend` in both `registry-mirrors` and `insecure-registries`. Refresh inline comments. |
| `charts/artifact-keeper/values-registry-cache.yaml` | Set `AK_DEFAULT_DOCKER_MIRROR_REPO=docker-hub-cache` on the cache backend so requests through the new mirror-mode fallback resolve via the existing `docker-hub-cache` proxy repo. Fix the wrong DNS comment next to `fullnameOverride`. |
| `docs/registry-cache.md` | Replace 4 references to the wrong DNS. |

## Apply order

1. Merge artifact-keeper PR #944 (release/1.1.x) and #945 (main) and bump `backend.image.tag` in `values-registry-cache.yaml` to a release containing the mirror-mode fallback (>= 1.1.9 / >= 1.2.0).
2. Sync the `registry-cache` ArgoCD Application; this rolls the `ak-cache` deployment with the new env var.
3. `kubectl apply -f e2e/dind-registry-mirror-configmap.yaml`.
4. Restart any running ARC runner pods so they pick up the new `daemon.json` (or wait for the next CI job, which scales fresh runners).
5. Smoke test: trigger a Coverage workflow run on `artifact-keeper` and confirm the `postgres:16-alpine` pull no longer hits Docker Hub (`toomanyrequests` goes away).

## Test Checklist
- [x] Helm template renders without errors -- `helm template ak-cache charts/artifact-keeper -f charts/artifact-keeper/values-registry-cache.yaml --set secrets.jwtSecret=t --set secrets.adminPassword=t --set postgres.auth.password=t` produces 774 lines, includes `name: AK_DEFAULT_DOCKER_MIRROR_REPO` / `value: "docker-hub-cache"` in the backend deployment env, and the rendered service is named `ak-cache-backend`.
- [ ] Terraform validates/plans cleanly -- N/A: no Terraform changes.
- [ ] Manually verified on staging cluster -- N/A: this IS the cluster the cache runs on; verification is the smoke test in the apply order above.
- [x] Rollback strategy documented -- revert this PR, re-sync ArgoCD, re-apply old configmap, restart runners. Rollback is safe because the AK backend mirror-mode fallback is opt-in via env var; with the env var unset the backend behaves identically to today.

## Infrastructure
- [x] Helm: `helm template` renders correctly (verified above).
- [ ] Terraform: N/A.
- [ ] ArgoCD: Application manifests are unchanged.
- [ ] N/A - documentation only

## Refs
- artifact-keeper#944 (release/1.1.x backend fix)
- artifact-keeper#945 (main backend fix)