### PR TITLE
chore(cache): bump ak-cache to mirror-mode image (sha-1f52e00)

### DIFF
--- a/charts/artifact-keeper/values-registry-cache.yaml
+++ b/charts/artifact-keeper/values-registry-cache.yaml
@@ -27,9 +27,19 @@
 
 # Pin to a known-good stable release. Bump only after smoke testing.
 # Do NOT use 'dev' or 'latest' here. Document upgrades in CHANGELOG.
+#
+# Temporarily pinned to a SHA tag because the mirror-mode routing fix
+# (artifact-keeper PR #944 / #945) hasn't been cut into a stable release
+# yet. `:sha-<commit>` is content-addressable and immutable, so it's
+# consistent with the spirit of the "no floating tags" rule. Replace
+# with the proper `1.1.9` (or `1.2.0`) tag once that release ships.
+#
+# Image: ghcr.io/artifact-keeper/artifact-keeper-backend:sha-1f52e00
+# Built from: artifact-keeper main commit 1f52e00 (PR #945, "fix(oci):
+# support Docker daemon registry-mirrors via env-configured fallback")
 backend:
   image:
-    tag: "1.1.8"
+    tag: "sha-1f52e00"
     pullPolicy: IfNotPresent
   replicaCount: 1
   env:


### PR DESCRIPTION
## Summary

Activates the mirror-mode routing fix that landed in artifact-keeper PR #945 by pinning the cache to its built image. With the previous `1.1.8` tag, the `AK_DEFAULT_DOCKER_MIRROR_REPO` env var that landed in #87 is just a no-op — the 1.1.8 build does not have the `resolve_repo` fallback.

Pinning to `:sha-1f52e00` (content-addressable, immutable) is a deliberate temporary measure until 1.1.9 / 1.2.0 ships. Replace with the proper version tag at that time.

**Why a SHA tag, not v1.1.9:**
The docker-publish workflow on `release/1.1.x` was an old version that only triggered on `[main, master]` branches (missing `release/1.1.x` in its trigger list), so the merge of artifact-keeper #944 did not produce a 1.1.x build. PR #945 (same fix on main) DID build, producing `:sha-1f52e00`. Same code, content-addressable image — fully consistent with the pin policy.

Once 1.1.9 ships properly (separate workflow-fix PR + release cut), bump back to a clean version tag.

## Apply order (post-merge)

```bash
# 1. Pull the merged values
git -C artifact-keeper-iac pull --ff-only

# 2. Helm upgrade in-place (the cache deployment was created via direct helm install,
#    not ArgoCD)
helm upgrade ak-cache charts/artifact-keeper \
  -f charts/artifact-keeper/values-registry-cache.yaml \
  --namespace infra-registry-cache --reuse-values

# 3. Apply the fixed configmap (#87 already added the corrected service name;
#    re-applying ensures dind picks it up)
kubectl apply -f e2e/dind-registry-mirror-configmap.yaml

# 4. Restart any running ARC runner pods so dind picks up the new daemon.json
#    (or wait — fresh runners pick it up automatically on next CI job)
kubectl delete pods -n arc-runners -l app.kubernetes.io/component=runner --wait=false || true
```

## Smoke test

```bash
# Verify mirror-mode fallback works on the new pod
kubectl exec -n infra-registry-cache deploy/ak-cache-backend -c backend -- \
  curl -sf -H "Authorization: Bearer anonymous" \
  http://localhost:8080/v2/library/postgres/manifests/16-alpine \
  -o /dev/null -w '%{http_code}\n'

# Expected: 200 (fallback routes to docker-hub-cache, manifest is fetched/cached from upstream)
# Pre-fix:  404 NAME_UNKNOWN: repository not found: library
```

Once the smoke test passes, the next CI Coverage job on artifact-keeper PRs should stop hitting Docker Hub anonymous rate limits — the dind sidecar will pull `postgres:16-alpine` through the in-cluster cache.

## Test Checklist
- [x] Helm template renders without errors -- `helm template` produces the deployment with `image: "ghcr.io/artifact-keeper/artifact-keeper-backend:sha-1f52e00"`.
- [ ] Terraform validates/plans cleanly -- N/A.
- [ ] Manually verified on staging cluster -- N/A: this IS the cluster the cache runs on; verification is the smoke test above.
- [x] Rollback strategy documented -- revert this PR, `helm upgrade --reuse-values --set backend.image.tag=1.1.8`. Rollback is safe; the 1.1.8 image ignores `AK_DEFAULT_DOCKER_MIRROR_REPO` (the env var has no effect on builds without the fallback code).

## Infrastructure
- [x] Helm: `helm template` renders correctly.
- [ ] Terraform: N/A.
- [ ] ArgoCD: Application unchanged. Note: the `ak-cache` deployment is currently `helm install`-managed, NOT ArgoCD-managed (no `registry-cache` Application exists in `argocd` namespace today). Migrating to ArgoCD is out of scope for this PR.
- [ ] N/A - documentation only

## Refs
- artifact-keeper-iac#87 (configmap fix + env wiring) — MERGED
- artifact-keeper#944 (release/1.1.x backend, no docker-publish run because workflow trigger missing release/1.1.x) — MERGED
- artifact-keeper#945 (main backend, source of `:sha-1f52e00`) — MERGED

## Follow-ups (out of scope)
- Backport docker-publish workflow update to release/1.1.x so future 1.1.x merges build images automatically.
- Cut v1.1.9 release; replace `sha-1f52e00` pin with `1.1.9` here.