### PR TITLE
docs: fix broken jwtSecret arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ helm install ak charts/artifact-keeper/ \
   --namespace artifact-keeper \
   --create-namespace \
   --set ingress.host=registry.example.com \
-  --set secrets.jwtSecret=$(openssl rand -base64 64) \
+  --set secrets.jwtSecret=$(openssl rand 64 | openssl base64 -A) \
   --set externalDatabase.host=your-rds-endpoint.amazonaws.com
 ```
 

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -172,7 +172,7 @@ helm install ak charts/artifact-keeper/ \
   --create-namespace \
   --set ingress.host=registry.example.com \
   --set externalDatabase.host=your-rds-endpoint.amazonaws.com \
-  --set secrets.jwtSecret=$(openssl rand -base64 64)
+  --set secrets.jwtSecret=$(openssl rand 64 | openssl base64 -A)
 ```
 
 ### Smoke / Release-Gate Testing

--- a/charts/artifact-keeper/README.md.gotmpl
+++ b/charts/artifact-keeper/README.md.gotmpl
@@ -117,7 +117,7 @@ helm install ak charts/artifact-keeper/ \
   --create-namespace \
   --set ingress.host=registry.example.com \
   --set externalDatabase.host=your-rds-endpoint.amazonaws.com \
-  --set secrets.jwtSecret=$(openssl rand -base64 64)
+  --set secrets.jwtSecret=$(openssl rand 64 | openssl base64 -A)
 ```
 
 ### Smoke / Release-Gate Testing


### PR DESCRIPTION
## Summary

```sh
uname -mprs
# Darwin 25.4.0 arm64 arm
```

> For writing, by default output is divided to lines of length 64 characters and there is a newline at the end of output. This behavior can be changed with BIO_FLAGS_BASE64_NO_NL flag.

See also [BIO_f_base64](https://docs.openssl.org/3.4/man3/BIO_f_base64/#synopsis:~:text=For%20writing%2C%20by%20default%20output%20is%20divided%20to%20lines%20of%20length%2064%20characters%20and%20there%20is%20a%20newline%20at%20the%20end%20of%20output.%20This%20behavior%20can%20be%20changed%20with%20BIO_FLAGS_BASE64_NO_NL%20flag.)

`openssl rand -base64 64` ouputs line breaks every 64 characters and at the end, so the command would throw:

```console
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments:
```

## Test Checklist
- [x] Helm template renders without errors
- [x] Terraform validates/plans cleanly
- [x] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [x] Terraform: `terraform validate` passes
- [x] Terraform: `terraform plan` shows expected changes
- [x] ArgoCD: Application manifests are valid
- [x] N/A - documentation only
