### PR TITLE
docs(chart): document chart-version <-> backend-version compatibility matrix (#91)

### DIFF
--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -22,6 +22,19 @@ This chart deploys [Artifact Keeper](https://github.com/artifact-keeper/artifact
 
 All files in this chart are provided as example configurations. Review and modify them to match your specific infrastructure requirements, security policies, and operational needs before use in production.
 
+## Compatibility Matrix
+
+The chart and backend versions must match. The current chart on `main` deploys OpenSearch (replacing Meilisearch from v1.1.x), so it requires backend v1.2.0 or later.
+
+| Chart version | Backend image | Search backend |
+|---|---|---|
+| `main` (unreleased v1.2.x) | v1.2.0+ (`:dev`, `:1.2-dev`, or `:1.2.0`+) | OpenSearch |
+| tag `chart-1.1.x` (planned) | v1.1.x line | Meilisearch |
+
+For deployments running backend v1.1.x, pin the chart to a tag matching that line. Mixing chart `main` with backend `:1.1-dev` will fail at startup because the backend will not find an OpenSearch endpoint.
+
+Tracking issues: chart release tags are coordinated in [#74](https://github.com/artifact-keeper/artifact-keeper-iac/issues/74), and a published Helm repository is tracked in [#51](https://github.com/artifact-keeper/artifact-keeper-iac/issues/51).
+
 ## Prerequisites
 
 - Kubernetes 1.26+
@@ -38,15 +51,7 @@ echo "vm.max_map_count = 262144" >> /etc/sysctl.d/99-opensearch.conf
 
 ## Installing the Chart
 
-Install the chart with the release name `ak`:
-
-```bash
-helm install ak artifact-keeper/artifact-keeper \
-  --namespace artifact-keeper \
-  --create-namespace
-```
-
-Or install from a local checkout:
+Install the chart from a local clone with the release name `ak`:
 
 ```bash
 git clone https://github.com/artifact-keeper/artifact-keeper-iac.git
@@ -55,6 +60,10 @@ helm install ak charts/artifact-keeper/ \
   --namespace artifact-keeper \
   --create-namespace
 ```
+
+A published Helm repository at `https://artifact-keeper.github.io/artifact-keeper-iac/` is planned but not yet live (see [issue #51](https://github.com/artifact-keeper/artifact-keeper-iac/issues/51)). Once published, the equivalent install command will be `helm install ak artifact-keeper/artifact-keeper`.
+
+If you are running backend v1.1.x, do not install from `main`. See the [Compatibility Matrix](#compatibility-matrix) above for chart/backend version pairing.
 
 These commands deploy Artifact Keeper with the default development configuration. See the [Values](#values) section for the full list of configurable parameters.
 

--- a/charts/artifact-keeper/README.md.gotmpl
+++ b/charts/artifact-keeper/README.md.gotmpl
@@ -22,6 +22,19 @@ This chart deploys [Artifact Keeper](https://github.com/artifact-keeper/artifact
 
 All files in this chart are provided as example configurations. Review and modify them to match your specific infrastructure requirements, security policies, and operational needs before use in production.
 
+## Compatibility Matrix
+
+The chart and backend versions must match. The current chart on `main` deploys OpenSearch (replacing Meilisearch from v1.1.x), so it requires backend v1.2.0 or later.
+
+| Chart version | Backend image | Search backend |
+|---|---|---|
+| `main` (unreleased v1.2.x) | v1.2.0+ (`:dev`, `:1.2-dev`, or `:1.2.0`+) | OpenSearch |
+| tag `chart-1.1.x` (planned) | v1.1.x line | Meilisearch |
+
+For deployments running backend v1.1.x, pin the chart to a tag matching that line. Mixing chart `main` with backend `:1.1-dev` will fail at startup because the backend will not find an OpenSearch endpoint.
+
+Tracking issues: chart release tags are coordinated in [#74](https://github.com/artifact-keeper/artifact-keeper-iac/issues/74), and a published Helm repository is tracked in [#51](https://github.com/artifact-keeper/artifact-keeper-iac/issues/51).
+
 ## Prerequisites
 
 - Kubernetes 1.26+
@@ -38,15 +51,7 @@ echo "vm.max_map_count = 262144" >> /etc/sysctl.d/99-opensearch.conf
 
 ## Installing the Chart
 
-Install the chart with the release name `ak`:
-
-```bash
-helm install ak artifact-keeper/artifact-keeper \
-  --namespace artifact-keeper \
-  --create-namespace
-```
-
-Or install from a local checkout:
+Install the chart from a local clone with the release name `ak`:
 
 ```bash
 git clone https://github.com/artifact-keeper/artifact-keeper-iac.git
@@ -55,6 +60,10 @@ helm install ak charts/artifact-keeper/ \
   --namespace artifact-keeper \
   --create-namespace
 ```
+
+A published Helm repository at `https://artifact-keeper.github.io/artifact-keeper-iac/` is planned but not yet live (see [issue #51](https://github.com/artifact-keeper/artifact-keeper-iac/issues/51)). Once published, the equivalent install command will be `helm install ak artifact-keeper/artifact-keeper`.
+
+If you are running backend v1.1.x, do not install from `main`. See the [Compatibility Matrix](#compatibility-matrix) above for chart/backend version pairing.
 
 These commands deploy Artifact Keeper with the default development configuration. See the [Values](#values) section for the full list of configurable parameters.
 


### PR DESCRIPTION
## Summary

The Helm chart on `main` switched to OpenSearch in #67 (replacing Meilisearch). That means the chart at `main`/`latest` only works with backend v1.2.0+, and users running backend v1.1.x who pull the latest chart will hit confusing failures at startup (the backend cannot find an OpenSearch endpoint).

This PR documents that contract on the chart README:

- Adds a **Compatibility Matrix** section spelling out which chart version pairs with which backend version and which search backend is bundled.
- Updates the **Installing the Chart** example to drop the `helm install ak artifact-keeper/artifact-keeper` form (which assumes a published Helm repo that is not yet live, tracked in #51) in favor of the local-clone install path, with a forward note about the planned repo.
- Cross-links the existing tracking issues (#51 published Helm repo, #74 chart release tags) so readers know the gaps are known and scoped.

Both `README.md.gotmpl` (the template) and `README.md` (the helm-docs output) are updated together so the existing Helm Docs CI drift check passes.

Fixes #91.

## Out of scope

- Actually publishing the Helm repository at `https://artifact-keeper.github.io/artifact-keeper-iac/` (#51).
- Cutting the `chart-1.1.x` tag and aligning chart release tags with backend release tags (#74).

## Test Checklist
- [ ] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [ ] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - documentation only