### PR TITLE
fix(rbac): grant pods/exec to e2e runner ClusterRole

### DIFF
--- a/e2e/runner-rbac.yaml
+++ b/e2e/runner-rbac.yaml
@@ -34,8 +34,11 @@ rules:
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 
   # Core workload resources (Helm chart deploys these)
+  # pods/exec is needed by the clean-install smoke test to run /readyz
+  # probes from inside the cluster (either against the backend pod when it
+  # ships curl/wget, or against an ephemeral curl pod when it does not).
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "services", "configmaps", "persistentvolumeclaims", "serviceaccounts"]
+    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "persistentvolumeclaims", "serviceaccounts"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 
   # Apps (Deployments, StatefulSets managed by Helm)


### PR DESCRIPTION
## Summary

The clean-install smoke test (`scripts/clean-install-smoke.sh` in `artifact-keeper-test`) runs `kubectl exec` against pods to probe `/readyz` from inside the cluster. The runner service account `ak-e2e-runners-gha-rs-no-permission` (auto-created by the ARC chart) is bound to the `arc-e2e-runner` ClusterRole, which grants `pods/log` but **not** `pods/exec`.

Every `kubectl exec` call from the runner has been silently denied. The smoke script's `2>/dev/null` masked the `Forbidden` error and surfaced it as a misleading "neither curl nor wget" message:

```
Error from server (Forbidden): pods "ak-smoke-probe-..." is forbidden:
User "system:serviceaccount:arc-runners:ak-e2e-runners-gha-rs-no-permission"
cannot create resource "pods/exec" in API group "" in the namespace "smoke-..."
```

This explains why the v1.1.9 release-gate has been failing on smoke across multiple attempts ([run 25181033570](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/25181033570)).

## Change

One line in `e2e/runner-rbac.yaml`: add `pods/exec` to the resources list of the existing pods rule. Same verbs apply.

## To take effect

This file is not auto-deployed. After merge:

```bash
ssh rocky 'sudo kubectl apply -f /path/to/runner-rbac.yaml'
```

(Per the workflow noted at the top of the file: "Apply with: kubectl apply -f e2e/runner-rbac.yaml".)

## Why pods/exec is the right scope

`pods/exec` is the standard Kubernetes verb for running commands in containers. It's narrower than `pods/portforward` and well-bounded; the runner can already create and delete pods in test namespaces, so granting exec doesn't widen the blast radius materially. It IS still elevated permission, but the runner SA is already trusted with `secrets`, `roles`, and `rolebindings` create/delete in test namespaces, so this fits the existing trust model.

## Regression test

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A - RBAC config change. The regression test is the next release-gate run reaching `Backend /readyz returned 200` instead of failing on the silent Forbidden.

## Related

- artifact-keeper#886 v1.1.9 stability release tracking
- artifact-keeper-test#102 rate-limit values fix (sibling test-infra item)
- artifact-keeper-test#103 smoke probe fallback (this PR is the missing complement)