### PR TITLE
fix(chart): gate scan-workspace and shared-config PVCs on their own feature flags

### DIFF
--- a/charts/artifact-keeper/templates/backend-pvc.yaml
+++ b/charts/artifact-keeper/templates/backend-pvc.yaml
@@ -24,8 +24,9 @@ spec:
   {{- if .Values.backend.persistence.storageClass }}
   storageClassName: {{ .Values.backend.persistence.storageClass | quote }}
   {{- end }}
+{{- end }}
+{{- if and .Values.backend.enabled .Values.backend.scanWorkspace.enabled }}
 ---
-{{- if .Values.backend.scanWorkspace.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -43,8 +44,8 @@ spec:
   storageClassName: {{ .Values.backend.persistence.storageClass | quote }}
   {{- end }}
 {{- end }}
----
 {{- if .Values.dependencyTrack.enabled }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -61,5 +62,4 @@ spec:
   {{- if .Values.backend.persistence.storageClass }}
   storageClassName: {{ .Values.backend.persistence.storageClass | quote }}
   {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

`templates/backend-pvc.yaml` wraps all three PVCs (storage, scan-workspace, shared-config) in a single outer `{{- if and .Values.backend.enabled .Values.backend.persistence.enabled }}`. Disabling `backend.persistence.enabled` (e.g. when the backend uses an object-store such as S3/GCS) therefore silently drops the scan-workspace and shared-config PVCs as well, leaving `scanWorkspace`- and `dependencyTrack`-enabled installs unschedulable.

Each PVC already carries its own inner conditional (`backend.scanWorkspace.enabled`, `dependencyTrack.enabled`); this PR lifts them out from under the persistence gate so they're honored independently.

### Repro

```
helm template ak charts/artifact-keeper \
  --set backend.persistence.enabled=false \
  --set backend.scanWorkspace.enabled=true \
  --set dependencyTrack.enabled=true \
  | grep "name: ak-artifact-keeper-"
```

Before: no PVCs render. After: scan-workspace and shared-config render; storage is correctly omitted.

### Backwards compatibility

The default install (`persistence.enabled=true`, `scanWorkspace.enabled=true`, `dependencyTrack.enabled=true`) renders byte-identical output — `diff` of `helm template` before/after is empty.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly  *(N/A — chart-only change)*
- [x] Manually verified on staging cluster (running in a dev GKE deploy)
- [x] Rollback strategy documented *(revert the patch — default behavior is byte-identical)*

## Infrastructure
- [x] Helm: `helm template` renders correctly (5 value combos validated: defaults; persistence=false × scan/dtrack on/off matrix; all-disabled)
- [ ] Terraform: `terraform validate` passes *(N/A)*
- [ ] Terraform: `terraform plan` shows expected changes *(N/A)*
- [ ] ArgoCD: Application manifests are valid *(N/A)*
- [ ] N/A - documentation only