### PR TITLE
fix(chart): set strategy: Recreate on backend Deployment

### DIFF
--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -19,6 +19,8 @@ spec:
   {{- if not .Values.backend.autoscaling.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "artifact-keeper.backend.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

The backend Deployment has no `strategy:` block, so Kubernetes defaults to RollingUpdate with `maxSurge: 25%`. For `replicas: 1`, that surges an extra pod during rollout. The backend mounts RWO PVCs (`ak-scan-workspace`, `ak-shared-config`) that the chart shares with trivy and the dependency-track init flow. When the surge pod schedules on a different node from the outgoing pod, both pods race for the same RWO volume and hit `FailedAttachVolume: Multi-Attach error`, deadlocking the rollout: the new pod can't become Ready (volume held by the old pod), and the old pod can't be scaled down (new pod isn't Ready).

The chart already applies `strategy: Recreate` to `trivy-deployment.yaml` and `dtrack-deployment.yaml` for exactly this single-writer-PVC reason — the backend Deployment was just missed. This PR adds the same two-line block to backend, matching the existing pattern verbatim.

Trade-off: ~30s of downtime per rollout for `replicas: 1`, in exchange for actually-working rollouts when scan-workspace or dependency-track PVCs are mounted. Operators running HA on RWX storage can switch the strategy back via a follow-up `backend.strategy` values knob if anyone needs it. Defaulting to `Recreate` matches what trivy/dtrack already do unconditionally.

Observed deadlocking a CloudSQL+GCS GKE deployment of AK 1.1.9. Applying `strategy: Recreate` resolved it; the patch has been running in that cluster for several rollouts without issue.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly *(N/A — chart-only change)*
- [x] Manually verified on staging cluster (dev GKE deploy)
- [x] Rollback strategy documented *(revert this commit; no state changes)*

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [x] Helm: `helm lint` clean
- [x] Helm: `helm-docs` is a no-op (no values changes)
- [ ] Terraform: `terraform validate` passes *(N/A)*
- [ ] Terraform: `terraform plan` shows expected changes *(N/A)*
- [ ] ArgoCD: Application manifests are valid *(N/A)*
- [ ] N/A - documentation only