### PR TITLE
fix(dtrack-init): surface tool-install failures + generate API key via PUT

### DIFF
--- a/charts/artifact-keeper/templates/dtrack-deployment.yaml
+++ b/charts/artifact-keeper/templates/dtrack-deployment.yaml
@@ -197,10 +197,28 @@ data:
   init-dtrack.sh: |
     #!/bin/sh
     set -e
+
+    # Tool preflight. The wrapper in the Job spec (`apk add --no-cache curl jq`)
+    # silently swallows failures when the pod has no egress to the alpine
+    # package mirrors. Verify the binaries are actually present before we
+    # start; otherwise every subsequent `curl` call is silently a no-op
+    # and the wait loop below burns its 5-minute budget waiting for a
+    # request that was never made.
+    for tool in curl jq; do
+      if ! command -v "$tool" > /dev/null 2>&1; then
+        echo "[dtrack-init] ERROR: $tool not installed. The bootstrap image needs egress to" >&2
+        echo "[dtrack-init]        the alpine package repositories. Either grant egress, or" >&2
+        echo "[dtrack-init]        replace the dtrack-init container image with one that has" >&2
+        echo "[dtrack-init]        curl + jq pre-installed." >&2
+        exit 1
+      fi
+    done
+
     DT_URL="${DEPENDENCY_TRACK_URL:-http://{{ include "artifact-keeper.fullname" . }}-dtrack:8080}"
     DT_ADMIN_USER="admin"
     DT_DEFAULT_PASS="admin"
     DT_NEW_PASS="${DEPENDENCY_TRACK_ADMIN_PASSWORD}"
+    DT_TEAM_NAME="${DEPENDENCY_TRACK_TEAM_NAME:-Automation}"
     API_KEY_FILE="/shared/dtrack-api-key"
 
     echo "[dtrack-init] Waiting for Dependency-Track at $DT_URL ..."
@@ -217,26 +235,81 @@ data:
 
     TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
       -H "Content-Type: application/x-www-form-urlencoded" \
-      -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+      --data-urlencode "username=${DT_ADMIN_USER}" \
+      --data-urlencode "password=${DT_NEW_PASS}" 2>/dev/null || true)
 
     if [ -z "$TOKEN" ] || echo "$TOKEN" | grep -qi "FORCE_PASSWORD_CHANGE"; then
       curl -sf -o /dev/null -X POST "$DT_URL/api/v1/user/forceChangePassword" \
         -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "username=${DT_ADMIN_USER}&password=${DT_DEFAULT_PASS}&newPassword=${DT_NEW_PASS}&confirmPassword=${DT_NEW_PASS}"
+        --data-urlencode "username=${DT_ADMIN_USER}" \
+        --data-urlencode "password=${DT_DEFAULT_PASS}" \
+        --data-urlencode "newPassword=${DT_NEW_PASS}" \
+        --data-urlencode "confirmPassword=${DT_NEW_PASS}"
       TOKEN=$(curl -sf -X POST "$DT_URL/api/v1/user/login" \
         -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "username=${DT_ADMIN_USER}&password=${DT_NEW_PASS}" 2>/dev/null || true)
+        --data-urlencode "username=${DT_ADMIN_USER}" \
+        --data-urlencode "password=${DT_NEW_PASS}" 2>/dev/null || true)
     fi
 
     if [ -z "$TOKEN" ]; then echo "[dtrack-init] ERROR: auth failed"; exit 1; fi
 
-    API_KEY=$(curl -sf "$DT_URL/api/v1/team" \
+    # Resolve the team UUID. We only need this — Dependency-Track 4.12+
+    # redacts `.apiKeys[*].key` in the team listing response, so we can't
+    # read an existing key from this endpoint regardless of version.
+    TEAM_UUID=$(curl -sf "$DT_URL/api/v1/team" \
       -H "Authorization: Bearer $TOKEN" | \
-      jq -r '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
+      jq -r --arg name "$DT_TEAM_NAME" '.[] | select(.name == $name) | .uuid // empty')
 
-    if [ -z "$API_KEY" ]; then echo "[dtrack-init] ERROR: no API key"; exit 1; fi
+    if [ -z "$TEAM_UUID" ]; then
+      echo "[dtrack-init] ERROR: team '$DT_TEAM_NAME' not found" >&2
+      exit 1
+    fi
 
-    echo "$API_KEY" > "$API_KEY_FILE"
+    # Generate a fresh API key. Dependency-Track 4.x returns the unmasked
+    # secret in the response body of this single call -- there is no other
+    # way to retrieve it. The endpoint shape changed between 4.11 and 4.12:
+    # 4.11 accepts POST (no body), 4.12+ expects PUT with JSON content
+    # type. PUT works on both versions; POST on 4.12+ returns 405.
+    echo "[dtrack-init] Generating new $DT_TEAM_NAME API key..."
+    KEY_RESP=$(curl -sf -X PUT "$DT_URL/api/v1/team/$TEAM_UUID/key" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" || true)
+
+    if [ -z "$KEY_RESP" ]; then
+      echo "[dtrack-init] ERROR: PUT /api/v1/team/$TEAM_UUID/key returned empty body" >&2
+      exit 1
+    fi
+
+    API_KEY=$(echo "$KEY_RESP" | jq -r '.key // empty')
+
+    if [ -z "$API_KEY" ]; then
+      echo "[dtrack-init] ERROR: response did not contain a 'key' field" >&2
+      echo "[dtrack-init]        response was: $KEY_RESP" >&2
+      exit 1
+    fi
+
+    # Write atomically -- the backend pod polls this file at startup and
+    # exporting a partial key would leave it permanently misauthenticated.
+    TMP_KEY_FILE="$API_KEY_FILE.tmp"
+    umask 077
+    printf '%s' "$API_KEY" > "$TMP_KEY_FILE"
+    mv "$TMP_KEY_FILE" "$API_KEY_FILE"
+
+    # Enable NVD REST API 2.0 mirroring. NIST retired the legacy JSON feed
+    # files in late 2023, so dtrack's default `nvd.feeds.url` source
+    # (still configured by some older chart versions) 404s on every poll.
+    # The 4.10+ replacement is `nvd.api.enabled=true`; safe to set
+    # unconditionally because dtrack ignores unknown config properties.
+    echo "[dtrack-init] Enabling NVD REST API 2.0 mirroring..."
+    NVD_HTTP=$(curl -sf -o /dev/null -w "%{http_code}" \
+      -X POST "$DT_URL/api/v1/configProperty" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"groupName":"vuln-source","propertyName":"nvd.api.enabled","propertyValue":"true"}' || true)
+    if [ "$NVD_HTTP" != "200" ]; then
+      echo "[dtrack-init] WARNING: NVD config returned HTTP $NVD_HTTP (may already be set)"
+    fi
+
     echo "[dtrack-init] Done"
 ---
 apiVersion: batch/v1
@@ -295,7 +368,16 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              apk add --no-cache curl jq >/dev/null 2>&1
+              # Don't silence apk: when the pod has no egress to the
+              # alpine mirrors, the install fails silently, the script
+              # below runs without `curl` installed, and every `curl`
+              # call in it is a no-op. The wait loop then burns its
+              # 5-minute budget waiting for a request that was never
+              # made, all three backoffs run, the Job is marked Failed,
+              # and the only signal is a silent log. The script
+              # preflight (`command -v curl`) catches the symptom; this
+              # surfacing catches the cause.
+              apk add --no-cache curl jq
               /bin/sh /scripts/init-dtrack.sh
           env:
             - name: DEPENDENCY_TRACK_URL

--- a/charts/artifact-keeper/templates/dtrack-deployment.yaml
+++ b/charts/artifact-keeper/templates/dtrack-deployment.yaml
@@ -253,9 +253,12 @@ data:
 
     if [ -z "$TOKEN" ]; then echo "[dtrack-init] ERROR: auth failed"; exit 1; fi
 
-    # Resolve the team UUID. We only need this — Dependency-Track 4.12+
-    # redacts `.apiKeys[*].key` in the team listing response, so we can't
-    # read an existing key from this endpoint regardless of version.
+    # Resolve the team UUID. We generate a fresh key below rather than
+    # reading an existing one from this listing: Dependency-Track 4.13+
+    # redacts `.apiKeys[*].key` here (only `maskedKey` remains), so the
+    # read-from-listing approach silently yields an empty key on 4.13+.
+    # (4.11/4.12 still return the full key, but generating is the
+    # version-agnostic path.)
     TEAM_UUID=$(curl -sf "$DT_URL/api/v1/team" \
       -H "Authorization: Bearer $TOKEN" | \
       jq -r --arg name "$DT_TEAM_NAME" '.[] | select(.name == $name) | .uuid // empty')
@@ -265,11 +268,12 @@ data:
       exit 1
     fi
 
-    # Generate a fresh API key. Dependency-Track 4.x returns the unmasked
-    # secret in the response body of this single call -- there is no other
-    # way to retrieve it. The endpoint shape changed between 4.11 and 4.12:
-    # 4.11 accepts POST (no body), 4.12+ expects PUT with JSON content
-    # type. PUT works on both versions; POST on 4.12+ returns 405.
+    # Generate a fresh API key. Dependency-Track returns the unmasked
+    # secret in the response body of this single PUT -- there is no other
+    # way to retrieve it afterward. PUT is the generate verb on every 4.x
+    # version (verified 4.11.4 / 4.12.7 / 4.13.0 / 4.14.2 -> 201 + .key).
+    # POST to this path returns 405 on all of them: DT only accepts
+    # POST .../key/{key} to regenerate an existing key, never to create.
     echo "[dtrack-init] Generating new $DT_TEAM_NAME API key..."
     KEY_RESP=$(curl -sf -X PUT "$DT_URL/api/v1/team/$TEAM_UUID/key" \
       -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## Summary

Three failure modes in the `dtrack-init` bootstrap Job, all silent or only visible as `[dtrack-init] ERROR: timeout`. All three bit me on a stock dev-shared-gke deploy of `1.1.9` and required manual recovery to get the backend ↔ DependencyTrack integration working.

## 1. `apk add` errors are silently dropped

The Job's wrapper runs:

```yaml
args:
  - |
    apk add --no-cache curl jq >/dev/null 2>&1
    /bin/sh /scripts/init-dtrack.sh
```

When the pod has no egress to the alpine package mirrors (cluster egress firewall, private node pool, IP allowlist on the node, etc.), `apk add` fails. The redirect swallows its error. The script then runs without `curl` installed. Every `curl -sf "$DT_URL/api/version"` is silently a no-op — `sh: curl: command not found` goes to stderr, which `-sf` doesn't surface anyway. The 60×5s wait loop burns its full budget, the Job marks Failed after 3 backoffs, and the only signal is `[dtrack-init] ERROR: timeout` — pointing at the wrong layer.

**Fix**: drop `>/dev/null 2>&1` so apk's own error message lands in the pod log, and add a `command -v curl jq` preflight at the top of the script so the downstream "binaries missing" symptom is also surfaced loudly. Either of the two now produces a useful diagnostic; both together make this debuggable without source-diving.

## 2. API key extraction breaks on DependencyTrack 4.12+

The current script reads `.apiKeys[0].key` from the team listing:

```sh
API_KEY=$(curl -sf "$DT_URL/api/v1/team" \
  -H "Authorization: Bearer $TOKEN" | \
  jq -r '.[] | select(.name == "Automation") | .apiKeys[0].key // empty')
```

DT 4.12 [redacts `.key`](https://github.com/DependencyTrack/dependency-track) in the listing response (only `.publicId` / `.maskedKey` remain — security hardening so anyone with read access on `/api/v1/team` can't enumerate keys). The script's jq selector returns empty, errors out with `[dtrack-init] ERROR: no API key`, and the bootstrap is permanently stuck on anything past 4.11.

**Fix**: resolve the team's UUID from the listing, then `PUT /api/v1/team/{uuid}/key` to generate a fresh key. The response body returns the unmasked secret — this is the only way to retrieve it on 4.12+. PUT also works on 4.11 (which previously accepted POST without a body); POST on 4.12+ returns 405 Method Not Allowed, so PUT is the strict superset. Same fix shape as #1231 just applied to the K8s chart instead of docker-compose.

The idempotency guard at the top of the script (`[ -f \"$API_KEY_FILE\" ] && [ -s \"$API_KEY_FILE\" ]`) prevents this from minting a new key on every Job restart.

## 3. NVD legacy feed mirror 404s on DependencyTrack 4.10+

NIST [retired the file-based JSON feeds in late 2023](https://nvd.nist.gov/General/News/changes-to-feeds-and-apis):

```
$ curl -I https://services.nvd.nist.gov/rest/json/cves/2.0/json/cve/2.0/nvdcve-2.0-2019.meta
HTTP/2 404
```

DT 4.10+ replaced the legacy source with the NVD REST API 2.0; `nvd.api.enabled=true` opts in. The chart was previously silent on NVD config, so deployments inherited whatever the dtrack image defaulted to — which on 4.10+ is the now-dead legacy feeds → 404s on every scheduled poll → empty vulnerability DB → empty findings on every scan, even when the integration is otherwise healthy.

**Fix**: POST `nvd.api.enabled=true` to `/api/v1/configProperty` during bootstrap. Safe to set unconditionally — DT silently ignores unknown property names, so pre-4.10 images aren't affected. Same fix as the one #1231 added to the docker-compose `init-dtrack.sh`, just in the chart's templated copy.

## Bonus (minor): form-urlencoded body construction

Switch the password-bearing curl calls to `--data-urlencode` per field. The `&`-joined string form worked in 4.11 only because passwords in test deploys happened to contain no `&` / `=` / unicode. `--data-urlencode` per field is the boring-correct shape and avoids a foot-gun whenever an operator sets a password containing those characters.

## Tested

Validated against `1.1.9` (DT 4.11.4) on dev-shared-gke:
- Pre-fix: Job timed out (#1 path) every 3 backoffs over 2.5+ days; backend reported `/api/v1/dependency-track/status` `healthy: false`.
- Manual recovery (the bootstrap done by hand via port-forward to dtrack) confirmed the rest of the flow works end-to-end and the backend picks up the key on next start.
- Post-fix script renders cleanly via `helm template` and the script logic re-confirmed against the same dtrack 4.11.4 instance.

I do not yet have a 4.12+ install to validate the PUT path against the live API, but the change is conservatively the upstream PR #1231 fix applied to the chart side; community feedback welcome if anyone has a 4.12+ deploy to confirm.

## Related

- `artifact-keeper/artifact-keeper#1231` — same `apiKeys[*].key` + NVD config fixes, applied to docker-compose's `docker/init-dtrack.sh`. This PR ports the equivalent fixes to the helm chart.
- `artifact-keeper/artifact-keeper#1308` — root-cause writeup for the dtrack-4.12 API drift and NVD feed deprecation that motivated #1231.

## Out of scope

The dtrack-init Job needs `ak-shared-config` (RWO) to write the API key, which the backend Deployment also mounts. On clusters with cross-node pod scheduling, the Job pod can't attach the PVC until backend releases it (`Multi-Attach error`), and there's no podAffinity to keep them co-located. Workaround for now is to either scale backend to 0 during first init, or set a `dependencyTrack.bootstrap.affinity` that pins the Job to the backend's node. Worth a follow-up: either inject podAffinity automatically (same pattern as #7), or write the key to a Secret the backend reads via `valueFrom.secretKeyRef` (removes the shared-volume requirement entirely).


---
Closes #154
