### PR TITLE
chore: pin production artifact keeper images

### DIFF
--- a/charts/artifact-keeper/values-production.yaml
+++ b/charts/artifact-keeper/values-production.yaml
@@ -11,7 +11,7 @@
 backend:
   replicaCount: 3
   image:
-    tag: latest
+    tag: "1.1.9"
   env:
     RUST_LOG: "info"
     ENVIRONMENT: "production"
@@ -49,7 +49,7 @@ backend:
 web:
   replicaCount: 3
   image:
-    tag: latest
+    tag: "1.1.9"
   resources:
     requests:
       cpu: 500m

--- a/charts/artifact-keeper/values-registry-cache.yaml
+++ b/charts/artifact-keeper/values-registry-cache.yaml
@@ -72,9 +72,9 @@ backend:
 
 # The cache is a pure pull-through OCI proxy. No UI needed, and the web
 # image release schedule is independent from the backend's so the version
-# tags don't necessarily align (e.g. backend has 1.1.8 but web does not).
-# Keep web disabled to avoid that coupling. Operators who want the UI for
-# debugging can deploy a separate AK install or temporarily enable this.
+# tags don't necessarily align. Keep web disabled to avoid that coupling.
+# Operators who want the UI for debugging can deploy a separate AK install
+# or temporarily enable this.
 web:
   enabled: false
 


### PR DESCRIPTION
Pins the production overlay to Artifact Keeper 1.1.9 for backend and web instead of floating latest tags, and cleans a stale registry-cache comment. SSO was verified working before this change.