### PR TITLE
fix(chart): drop the unused scan-workspace mount from the trivy Deployment

### DIFF
--- a/charts/artifact-keeper/templates/trivy-deployment.yaml
+++ b/charts/artifact-keeper/templates/trivy-deployment.yaml
@@ -85,11 +85,6 @@ spec:
               mountPath: /home/trivy/.cache
             - name: tmp
               mountPath: /tmp
-            {{- if .Values.backend.scanWorkspace.enabled }}
-            - name: scan-workspace
-              mountPath: /scan-workspace
-              readOnly: true
-            {{- end }}
       volumes:
         - name: tmp
           emptyDir:
@@ -97,11 +92,6 @@ spec:
         - name: trivy-cache
           persistentVolumeClaim:
             claimName: {{ include "artifact-keeper.fullname" . }}-trivy-cache
-        {{- if .Values.backend.scanWorkspace.enabled }}
-        - name: scan-workspace
-          persistentVolumeClaim:
-            claimName: {{ include "artifact-keeper.fullname" . }}-scan-workspace
-        {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary

The trivy Deployment mounts the `scan-workspace` PVC (`readOnly: true`), but trivy runs in **server mode** (`trivy server --listen 0.0.0.0:8090 …`) and never reads that path. The mount is dead weight — and it's what makes `scan-workspace` a *multi-Deployment* `ReadWriteOnce` volume (backend mounts it RW, trivy RO), which is the root cause of the cross-Deployment `FailedAttachVolume: Multi-Attach error` when the two pods schedule on different nodes.

This removes the `scan-workspace` `volumeMount` and `volume` from the trivy Deployment template (two-block deletion, no other changes). The backend becomes the sole consumer of `scan-workspace`, eliminating the contention class by construction — operators can then drop the `backend.affinity.podAffinity` rule that pins backend onto trivy's node.

Template-only change; no `values.yaml` / `Chart.yaml` edits, so the generated chart README is unaffected.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [ ] N/A - documentation only

Closes #123
