### PR TITLE
feat(chart): add HealthCheckPolicy for GKE Gateway environments

### DIFF
--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -86,6 +86,9 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | externalDatabase | object | `{"database":"artifact_registry","existingSecret":"","existingSecretKey":"DATABASE_URL","host":"","password":"","port":5432,"username":""}` | External database (used when postgres.enabled=false) |
 | externalSecrets | object | `{"enabled":false,"refreshInterval":"1h","secrets":{"dbCredentials":"artifact-keeper/${ENVIRONMENT}/db-credentials","dtAdminPassword":"artifact-keeper/${ENVIRONMENT}/dt-admin-password","jwtSecret":"artifact-keeper/${ENVIRONMENT}/jwt-secret","opensearchAuth":"artifact-keeper/${ENVIRONMENT}/opensearch-auth","s3Keys":"artifact-keeper/${ENVIRONMENT}/s3-keys","smtpPassword":"artifact-keeper/${ENVIRONMENT}/smtp-password"},"storeKind":"ClusterSecretStore","storeName":"aws-secrets-manager"}` | External Secrets Operator When enabled, ExternalSecret CRDs replace the static Secret template. Requires External Secrets Operator installed on the cluster and a SecretStore or ClusterSecretStore configured for your provider. |
 | fullnameOverride | string | `""` |  |
+| gke.healthCheckPolicies.backend.requestPath | string | `"/livez"` | Health-check path for the backend BackendService. |
+| gke.healthCheckPolicies.dependencyTrack.requestPath | string | `"/api/version"` | Health-check path for the DependencyTrack BackendService. |
+| gke.healthCheckPolicies.enabled | bool | `false` | Render a `networking.gke.io/v1` HealthCheckPolicy per Service so a GKE Gateway BackendService probes the app's real health path instead of `/` (which backend and DependencyTrack return 404 for). Leave disabled on non-GKE installs and on plain Ingress-based GKE. |
 | global.affinity | object | `{}` |  |
 | global.imagePullPolicy | string | `"Always"` |  |
 | global.imageRegistry | string | `"ghcr.io/artifact-keeper"` |  |

--- a/charts/artifact-keeper/templates/healthcheck-policies.yaml
+++ b/charts/artifact-keeper/templates/healthcheck-policies.yaml
@@ -1,0 +1,61 @@
+{{/*
+HealthCheckPolicy for GKE Gateway environments.
+
+On GKE clusters fronted by the Gateway API, each BackendService the controller
+creates from an HTTPRoute defaults to an HTTP `GET /` health check. The backend
+(Axum) and DependencyTrack both return 404 for `/` (they only serve their own
+API path prefixes), so the NEG endpoints are marked Unhealthy and Envoy returns
+`503 no healthy upstream`. The kubelet liveness/readiness probes don't help —
+the Gateway controller doesn't derive its check from them; it needs an explicit
+HealthCheckPolicy bound to the Service.
+
+Rendered only when `gke.healthCheckPolicies.enabled` is true, so installs on
+other clouds (or on plain Ingress-based GKE) are unaffected. Web is omitted on
+purpose — Next.js serves `/` with 200.
+*/}}
+{{- if .Values.gke.healthCheckPolicies.enabled }}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-backend
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: {{ .Values.backend.service.httpPort | default 8080 }}
+        requestPath: {{ .Values.gke.healthCheckPolicies.backend.requestPath | default "/livez" }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "artifact-keeper.fullname" . }}-backend
+{{- if .Values.dependencyTrack.enabled }}
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-dtrack
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dependency-track
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        {{- /* dependencyTrack has no `service:` block in values.yaml yet, so use a
+               nil-safe lookup (Go templates don't short-circuit nil parents, and
+               `| default` only catches a missing leaf). Adding
+               dependencyTrack.service.port to values would let this be a plain
+               `.Values.dependencyTrack.service.port`. */}}
+        port: {{ (.Values.dependencyTrack.service | default dict).port | default 8080 }}
+        requestPath: {{ .Values.gke.healthCheckPolicies.dependencyTrack.requestPath | default "/api/version" }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ include "artifact-keeper.fullname" . }}-dtrack
+{{- end }}
+{{- end }}

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -589,3 +589,18 @@ serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: 10s
+
+# GKE-specific resources. Only relevant on Google Kubernetes Engine.
+gke:
+  healthCheckPolicies:
+    # -- Render a `networking.gke.io/v1` HealthCheckPolicy per Service so a GKE
+    # Gateway BackendService probes the app's real health path instead of `/`
+    # (which backend and DependencyTrack return 404 for). Leave disabled on
+    # non-GKE installs and on plain Ingress-based GKE.
+    enabled: false
+    backend:
+      # -- Health-check path for the backend BackendService.
+      requestPath: /livez
+    dependencyTrack:
+      # -- Health-check path for the DependencyTrack BackendService.
+      requestPath: /api/version


### PR DESCRIPTION
## Summary

Adds an optional `networking.gke.io/v1` `HealthCheckPolicy` per Service for GKE Gateway environments. On GKE clusters fronted by the Gateway API, BackendServices default to an HTTP `GET /` health check; the backend (Rust/Axum) and DependencyTrack both return 404 for `/`, so NEG endpoints are marked Unhealthy and Envoy returns `503 no healthy upstream`. The kubelet liveness/readiness probes don't configure the Gateway's BackendService check — it needs an explicit `HealthCheckPolicy` bound to the Service.

New `templates/healthcheck-policies.yaml` renders a policy for the backend Service (`/livez`) and, when `dependencyTrack.enabled`, the DependencyTrack Service (`/api/version`), reusing the apps' real health paths. The whole file is guarded by a new `gke.healthCheckPolicies.enabled` value (default **false**), so non-GKE installs and plain Ingress-based GKE are unaffected. Web is omitted on purpose (Next.js serves `/` with 200).

Notes:
- Backend port reads `backend.service.httpPort`; the DependencyTrack port uses a nil-safe lookup (`(.Values.dependencyTrack.service | default dict).port | default 8080`) because the `dependencyTrack` values block has no `service:` sub-key yet — a small follow-up could add `dependencyTrack.service.port` and simplify this.
- `README.md` regenerated via helm-docs.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] N/A for Terraform / ArgoCD

Closes #125
