### PR TITLE
fix(rbac): add patch/update verbs on batch/jobs for ARC runner (closes #129)

### DIFF
--- a/e2e/runner-rbac.yaml
+++ b/e2e/runner-rbac.yaml
@@ -46,10 +46,13 @@ rules:
     resources: ["deployments", "statefulsets", "replicasets"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 
-  # Batch (Jobs used by mesh E2E tests)
+  # Batch (Jobs used by mesh E2E tests, plus the DTrack bootstrap Job
+  # the chart renders when dependencyTrack.enabled=true). Helm uses
+  # server-side apply which needs patch+update; the missing verbs were
+  # blocking every DTrack-enabled deploy (#129).
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
 
   # Networking (Services, Ingresses, NetworkPolicies from Helm chart)
   - apiGroups: ["networking.k8s.io"]


### PR DESCRIPTION
## Summary

The ARC runner ClusterRole grants `create, get, list, watch, delete` on `batch/jobs` but is missing `patch` and `update`. The artifact-keeper Helm chart's DTrack bootstrap creates a standalone `Kind=Job` (`artifact-keeper-dtrack-init`); `helm install`/`helm upgrade` uses server-side apply which requires `patch`. Result: every test namespace deploy with DTrack enabled fails with a forbidden error.

Discovered while running smoke-self-test fixtures for [artifact-keeper-test#202](https://github.com/artifact-keeper/artifact-keeper-test/pull/202) (DTrack standup in `values-test-full.yaml`).

Same RBAC matrix as `apps/deployments`, `[""]/configmaps`, and other Helm-managed resource types.

## Post-merge action

Apply the updated ClusterRole to Rocky:

```bash
ssh rocky kubectl apply -f /path/to/artifact-keeper-iac/e2e/runner-rbac.yaml
```

ClusterRole changes propagate to the bound ServiceAccount immediately; no pod restart needed.

## Test plan

- [x] Diff is 1 line of verb additions + comment clarification
- [ ] After merge + `kubectl apply` on Rocky, re-trigger smoke-self-test on artifact-keeper-test#202; verify the `artifact-keeper-dtrack-init` Job patch succeeds

Closes #129