### PR TITLE
fix(trivy): disable preseed init container by default (closes #137)

### DIFF
--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -513,8 +513,12 @@ trivy:
     javaRepository: "mirror.gcr.io/aquasecurity/trivy-java-db"
     # -- Run an init container that downloads the DB into the cache PVC before the
     # server starts. Makes the DB present on rollout instead of on first scan.
+    # Default OFF because the preseed download from mirror.gcr.io can exceed Helm's
+    # default install timeout in some clusters, leaving the Trivy Deployment stuck
+    # at Available 0/1 (see artifact-keeper-iac #137). The server still fetches the
+    # DB lazily on first scan via TRIVY_DB_REPOSITORY, so this is opt-in for now.
     preseed:
-      enabled: true
+      enabled: false
     # -- Skip the periodic in-server DB refresh. Leave false so the server keeps the
     # DB fresh from the configured mirror; set true for fully air-gapped clusters
     # where the DB is seeded out of band.


### PR DESCRIPTION
## Summary
PR #136's Trivy DB preseed init container is enabled by default. In the artifact-keeper-test release gate (run 26656317475), Helm install times out at 'Available 0/1' after 10 minutes, failing deploy and skipping every suite. Disable preseed by default until the hang root cause (mirror.gcr.io egress speed, readOnly FS, or an init-container-specific issue) is fixed. The server still fetches the DB lazily via TRIVY_DB_REPOSITORY env, which #136 also added.

## Change
- charts/artifact-keeper/values.yaml: trivy.db.preseed.enabled true -> false (with note pointing at #137).

Closes #137