### PR TITLE
fix(trivy): empty DB repository defaults so server boots with ghcr.io (closes #140)

### DIFF
--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -506,11 +506,15 @@ trivy:
   # the DB with an init container so it is present before the server accepts scans.
   db:
     # -- OCI repository for the vulnerability DB. Override to an internal mirror the
-    # cluster can reach. mirror.gcr.io fronts the same artifact as ghcr but is not
-    # subject to the ghcr anonymous-pull rate limit.
-    repository: "mirror.gcr.io/aquasecurity/trivy-db"
-    # -- OCI repository for the Java DB (used by jar/war scanning).
-    javaRepository: "mirror.gcr.io/aquasecurity/trivy-java-db"
+    # cluster can reach. Default empty means Trivy uses its built-in ghcr.io default,
+    # which has historically been the only reliably-reachable source from our gate
+    # cluster. mirror.gcr.io was tried in #136 but caused the server to hang at
+    # Available 0/1 even with preseed off (see artifact-keeper-iac #140), so the
+    # mirror is now opt-in by override rather than the default.
+    repository: ""
+    # -- OCI repository for the Java DB (used by jar/war scanning). Same opt-in
+    # semantics as `repository` above.
+    javaRepository: ""
     # -- Run an init container that downloads the DB into the cache PVC before the
     # server starts. Makes the DB present on rollout instead of on first scan.
     # Default OFF because the preseed download from mirror.gcr.io can exceed Helm's


### PR DESCRIPTION
## Summary
Even with iac #138 (preseed off), the artifact-keeper-test release gate (run 26663319894) still failed deploy with Trivy 'Available 0/1, context deadline exceeded'. The init container is gone; the server itself hangs. Most likely the new TRIVY_DB_REPOSITORY=mirror.gcr.io env (also added by #136) makes the server block during startup DB fetch.

## Change
charts/artifact-keeper/values.yaml: trivy.db.repository and trivy.db.javaRepository default to empty so the templated env conditionals skip and the server boots with its built-in ghcr.io default (which worked pre-#136). Anyone who wants the mirror can override in their own values file.

## Expected impact
- Deploy succeeds again. The other 20+ release-gate suites can run.
- pinned-cve-gate may stay flaky on ghcr.io rate limits (separate follow-up to address with a properly-seeded DB).
- No consumer impact unless they were depending on the default mirror.

Closes #140