### PR TITLE
fix(chart): use external-secrets.io/v1 API for ExternalSecret

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,7 +10,7 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.2.0"
 home: https://artifactkeeper.com
 sources:

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 ## TL;DR
 

--- a/charts/artifact-keeper/templates/external-secrets.yaml
+++ b/charts/artifact-keeper/templates/external-secrets.yaml
@@ -17,7 +17,7 @@ security policies, and operational needs before use in production.
 #    or static credentials for accessing AWS Secrets Manager.
 # 3. The referenced secrets must exist in AWS Secrets Manager with the
 #    expected JSON keys.
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "artifact-keeper.fullname" . }}-secrets


### PR DESCRIPTION
Bumps the ExternalSecret template from the deprecated `external-secrets.io/v1beta1` to `external-secrets.io/v1` (identical schema), so the chart deploys on clusters running a current External Secrets Operator. Chart version 1.2.0 -> 1.2.1, README regenerated.

Closes #147