### PR TITLE
fix(arc): raise sccache cache size to 50G on ak-ci-runners

### DIFF
--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -93,8 +93,12 @@ template:
           # atomic rename need one kernel / local fs).
           - name: SCCACHE_CACHE_SIZE
             value: "50G"
+          # Must live under a dir init-cache chmods to 777 — the /cache root
+          # itself is root:755, and an unwritable SCCACHE_ERROR_LOG kills the
+          # sccache server at startup, failing every compile job (2026-06-12
+          # outage).
           - name: SCCACHE_ERROR_LOG
-            value: /cache/sccache-error.log
+            value: /cache/sccache/sccache-error.log
         resources:
           requests:
             cpu: "2"

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -81,6 +81,20 @@ template:
             value: /cache/npm
           - name: SCCACHE_IDLE_TIMEOUT
             value: "0"
+          # Without an explicit size sccache defaults to 10 GiB; the shared
+          # /home/runner-cache/sccache hit that cap (verified 2026-06-12) and
+          # was evicting continuously. /home has 1.2T free; 50G holds the
+          # full dependency graph across clippy/unit profiles with headroom.
+          # NOTE: the size cap is enforced per sccache server process, and
+          # each runner pod runs its own server over this shared hostPath, so
+          # the effective cap is soft under concurrency. Harmless at this
+          # size, but don't tune it down expecting a hard bound. The shared
+          # dir is only safe while all runners land on one node (flock +
+          # atomic rename need one kernel / local fs).
+          - name: SCCACHE_CACHE_SIZE
+            value: "50G"
+          - name: SCCACHE_ERROR_LOG
+            value: /cache/sccache-error.log
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
## Problem

`SCCACHE_CACHE_SIZE` was never set on the `ak-ci-runners` scale set, so sccache used its 10 GiB default. The shared `/home/runner-cache/sccache` hostPath was verified at exactly 10G on 2026-06-12 — at cap and continuously evicting.

## Baseline (measured 2026-06-12, last 33h of CI / 595 runs over 7 days)

- ~30 cold rust builds/week, ~12 min penalty each (~6 h/week)
- GHA cache quota also at 10.49 GB / 10 GB with ~daily full turnover — both cache layers evicting simultaneously
- Total cache-churn cost ≈ 22 runner-hours/week (~8.5% of node capacity)

## Change

- `SCCACHE_CACHE_SIZE: 50G` (/home has 1.2T free)
- `SCCACHE_ERROR_LOG: /cache/sccache-error.log` for observability

## Apply

Per the file header: `helm upgrade --install ak-ci-runners --namespace arc-runners --version 0.13.1 -f argocd/arc-ci-runners-values.yaml oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set`

Note: this upgrade also deploys the iac#83 `init-dockerhub-creds` initContainer already in git but not yet on the cluster (rev 24 predates it). `dockerhub-pull` secret and `dind-registry-mirror` configmap verified present in `arc-runners`.

Companion PR (buildkit type=gha → GHCR registry cache) follows in artifact-keeper/artifact-keeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)