### PR TITLE
Pin rust runner image versions and bake in cargo-nextest

### DIFF
--- a/runner-images/rust/Dockerfile
+++ b/runner-images/rust/Dockerfile
@@ -1,4 +1,11 @@
-FROM ghcr.io/actions/actions-runner:latest
+# Pinning policy: base image and Rust tooling are pinned to explicit
+# versions so the runner environment only changes via deliberate,
+# reviewable bumps in this file -- never via :latest drift on rebuild.
+# This matters especially for sccache, where a silent version change
+# alters cache-hash behavior and invalidates the shared sccache cache.
+# To upgrade: bump the version here in a PR; merging to main rebuilds
+# and publishes the image automatically (.github/workflows/runner-images.yml).
+FROM ghcr.io/actions/actions-runner:2.335.1
 
 USER root
 
@@ -24,8 +31,16 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     rustup target add x86_64-pc-windows-gnu && \
     rustup --version && rustc --version && cargo --version
 
-# Install sccache
-RUN cargo install sccache --locked && sccache --version
+# Install sccache (pinned: version changes silently alter cache-hash behavior)
+ENV SCCACHE_VERSION=0.15.0
+RUN cargo install sccache --version "${SCCACHE_VERSION}" --locked && sccache --version
+
+# Install cargo-nextest (pinned). Baked into /usr/local/cargo/bin so it
+# stays on PATH even though CARGO_HOME is overridden to /cache/cargo-home
+# at runtime; per-run installs into the shared cache raced across pods.
+ENV CARGO_NEXTEST_VERSION=0.9.137
+RUN curl -LsSf "https://get.nexte.st/${CARGO_NEXTEST_VERSION}/linux" | \
+    tar zxf - -C /usr/local/cargo/bin && cargo nextest --version
 
 # Install cargo-llvm-cov for coverage
 RUN curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | \


### PR DESCRIPTION
## Summary
Closes #165

Hardens `runner-images/rust/Dockerfile` (published as `ghcr.io/artifact-keeper/ak-runner-rust`):

- Pin base image to `ghcr.io/actions/actions-runner:2.335.1` (current latest) instead of `:latest`, so rebuilds — including the weekly scheduled one — no longer pick up upstream changes silently.
- Pin sccache to **0.15.0**, the currently-deployed version, so cache-hash behavior is unchanged and the shared sccache cache is not invalidated. Future sccache bumps become deliberate, reviewable diffs.
- Bake **cargo-nextest 0.9.137** into `/usr/local/cargo/bin`. The coverage job currently installs it per-run via taiki-e/install-action into the shared `/cache/cargo-home` hostPath, which races across concurrent runner pods (ETXTBSY/torn binary). `/usr/local/cargo/bin` is on the image's baked PATH, so the binary stays reachable even though CARGO_HOME is overridden to `/cache/cargo-home` at runtime — same mechanism as the existing cargo-llvm-cov/sqlx-cli/cargo-audit binaries.
- Add a comment block documenting the pinning policy (bump deliberately via PR, never `:latest` drift).

No changes to `argocd/arc-ci-runners-values.yaml`; it references `:latest`, so merging this PR rolls the new image out to new runner pods automatically via the runner-images workflow.

Follow-up PR in artifact-keeper/artifact-keeper removes the per-run nextest install from the coverage job once this image is live.

## Test Checklist
- [ ] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [x] Manually verified on staging cluster (if applicable) — image built locally; `cargo nextest --version`, `sccache --version`, and existing tool layout verified before merge
- [x] Rollback strategy documented — re-run the runner-images workflow from the previous commit, or retag the prior `:run_number` image as `:latest`

## Infrastructure
- [ ] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - Dockerfile only