### PR TITLE
fix(arc): move dind docker root to /home with overlay2 (disk-pressure hazard)

### DIFF
--- a/argocd/arc-beefy-runners-values.yaml
+++ b/argocd/arc-beefy-runners-values.yaml
@@ -22,6 +22,7 @@
 #
 # Deployed via:
 #   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+#   kubectl apply -f e2e/runner-dind-cleanup.yaml
 #   kubectl -n arc-runners create secret docker-registry dockerhub-pull ...
 #     (see argocd/dockerhub-pull-secret.example.yaml)
 #   helm upgrade --install ak-beefy-runners \
@@ -40,7 +41,8 @@
 # Shape mirrors ak-ci-runners (known working) with doubled resources:
 #   - dind sidecar placed in initContainers with restartPolicy: Always
 #     (K8s native sidecar pattern, required for the 0.13 chart)
-#   - dockerd explicit args: --storage-driver=vfs (nested containers) and
+#   - dockerd explicit args: --storage-driver=overlay2 on a per-pod
+#     hostPath docker root under /home (see dind container comment) and
 #     --group=123 (for /var/run/docker.sock ACL to the runner user)
 #   - dind-var mounted at /var/run in both runner and sidecar so the runner
 #     can talk to the socket
@@ -134,10 +136,20 @@ template:
             mountPath: /home/runner/tmpDir
       - name: dind
         image: docker:27-dind
+        # overlay2 on a per-pod hostPath docker root under /home instead
+        # of vfs in the container writable layer on the 70G root disk.
+        # Full rationale in argocd/arc-ci-runners-values.yaml (dind
+        # container comment). Orphaned per-pod dirs are reaped by
+        # e2e/runner-dind-cleanup.yaml.
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         args:
           - dockerd
           - --host=unix:///var/run/docker.sock
-          - --storage-driver=vfs
+          - --storage-driver=overlay2
           - --group=123
         restartPolicy: Always
         securityContext:
@@ -157,6 +169,9 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          - name: dind-docker
+            mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)
           - name: dind-config
             mountPath: /etc/docker/daemon.json
             subPath: daemon.json
@@ -168,6 +183,12 @@ template:
         emptyDir: {}
       - name: dind-externals
         emptyDir: {}
+      # Per-pod docker roots for the dind sidecar; reaped by
+      # e2e/runner-dind-cleanup.yaml.
+      - name: dind-docker
+        hostPath:
+          path: /home/runner-dind
+          type: DirectoryOrCreate
       - name: dind-config
         configMap:
           name: dind-registry-mirror

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -93,8 +93,12 @@ template:
           # atomic rename need one kernel / local fs).
           - name: SCCACHE_CACHE_SIZE
             value: "50G"
+          # Must live under a dir init-cache chmods to 777 — the /cache root
+          # itself is root:755, and an unwritable SCCACHE_ERROR_LOG kills the
+          # sccache server at startup, failing every compile job (2026-06-12
+          # outage).
           - name: SCCACHE_ERROR_LOG
-            value: /cache/sccache-error.log
+            value: /cache/sccache/sccache-error.log
         resources:
           requests:
             cpu: "2"

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -31,6 +31,7 @@
 #
 # Deployed via:
 #   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+#   kubectl apply -f e2e/runner-dind-cleanup.yaml
 #   kubectl -n arc-runners create secret docker-registry dockerhub-pull ...
 #     (see argocd/dockerhub-pull-secret.example.yaml)
 #   helm upgrade --install ak-ci-runners \
@@ -170,10 +171,39 @@ template:
             mountPath: /cache
       - name: dind
         image: docker:27-dind
+        # DIND STORAGE (overlay2 on /home, NOT vfs on the root disk)
+        # ----------------------------------------------------------
+        # /var/lib/docker is a hostPath under /home/runner-dind with one
+        # subdir per pod via subPathExpr (concurrent dockerds must never
+        # share a docker root). Previously dockerd ran vfs with
+        # /var/lib/docker unmounted, so every image layer was a FULL
+        # DIRECTORY COPY landing in the container's writable layer under
+        # the crio graph root on the 70G root disk — 20 concurrent
+        # builders could exhaust it and trigger kubelet disk-pressure
+        # eviction of prod pods (root disk had ~25G free, 2026-06-12).
+        #
+        # overlay2 works here because the mount target is a plain xfs
+        # directory (ftype=1, verified on the rocky node): the RHEL 8
+        # 4.18 kernel only forbids overlay-ON-overlay, which is why vfs
+        # was used when /var/lib/docker sat on the crio overlay layer.
+        #
+        # Permissions: hostPath DirectoryOrCreate yields root:755;
+        # dockerd runs as root in a privileged container, so that is
+        # writable (unlike the SCCACHE_ERROR_LOG / 755-root incident —
+        # sccache runs unprivileged).
+        #
+        # Orphaned per-pod dirs (runner pods churn constantly; preStop is
+        # not guaranteed to run) are reaped by the runner-dind-cleanup
+        # CronJob: e2e/runner-dind-cleanup.yaml.
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         args:
           - dockerd
           - --host=unix:///var/run/docker.sock
-          - --storage-driver=vfs
+          - --storage-driver=overlay2
           - --group=123
         restartPolicy: Always
         securityContext:
@@ -193,6 +223,9 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          - name: dind-docker
+            mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)
           - name: dind-config
             mountPath: /etc/docker/daemon.json
             subPath: daemon.json
@@ -207,6 +240,13 @@ template:
       - name: runner-cache
         hostPath:
           path: /home/runner-cache
+          type: DirectoryOrCreate
+      # Per-pod docker roots for the dind sidecar (see dind container
+      # comment). Lives on /home (1.8T) to keep image-build I/O off the
+      # 70G root disk. Reaped by e2e/runner-dind-cleanup.yaml.
+      - name: dind-docker
+        hostPath:
+          path: /home/runner-dind
           type: DirectoryOrCreate
       - name: dind-config
         configMap:

--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -81,6 +81,20 @@ template:
             value: /cache/npm
           - name: SCCACHE_IDLE_TIMEOUT
             value: "0"
+          # Without an explicit size sccache defaults to 10 GiB; the shared
+          # /home/runner-cache/sccache hit that cap (verified 2026-06-12) and
+          # was evicting continuously. /home has 1.2T free; 50G holds the
+          # full dependency graph across clippy/unit profiles with headroom.
+          # NOTE: the size cap is enforced per sccache server process, and
+          # each runner pod runs its own server over this shared hostPath, so
+          # the effective cap is soft under concurrency. Harmless at this
+          # size, but don't tune it down expecting a hard bound. The shared
+          # dir is only safe while all runners land on one node (flock +
+          # atomic rename need one kernel / local fs).
+          - name: SCCACHE_CACHE_SIZE
+            value: "50G"
+          - name: SCCACHE_ERROR_LOG
+            value: /cache/sccache-error.log
         resources:
           requests:
             cpu: "2"

--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -22,6 +22,7 @@
 #
 # Deployed via:
 #   kubectl apply -f e2e/dind-registry-mirror-configmap.yaml
+#   kubectl apply -f e2e/runner-dind-cleanup.yaml
 #   kubectl -n arc-runners create secret docker-registry dockerhub-pull ...
 #     (see argocd/dockerhub-pull-secret.example.yaml)
 #   helm upgrade --install ak-e2e-runners \
@@ -113,14 +114,23 @@ template:
             mountPath: /home/runner/tmpDir
       - name: dind
         image: docker:dind
+        # overlay2 on a per-pod hostPath docker root under /home instead
+        # of vfs in the container writable layer on the 70G root disk.
+        # Full rationale in argocd/arc-ci-runners-values.yaml (dind
+        # container comment). Orphaned per-pod dirs are reaped by
+        # e2e/runner-dind-cleanup.yaml.
         args:
           - dockerd
           - --host=unix:///var/run/docker.sock
-          - --storage-driver=vfs
+          - --storage-driver=overlay2
           - --group=123
         env:
           - name: DOCKER_GROUP_GID
             value: "123"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         restartPolicy: Always
         securityContext:
           privileged: true
@@ -139,6 +149,9 @@ template:
             mountPath: /var/run
           - name: dind-externals
             mountPath: /home/runner/externals
+          - name: dind-docker
+            mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)
           - name: dind-config
             mountPath: /etc/docker/daemon.json
             subPath: daemon.json
@@ -150,6 +163,12 @@ template:
         emptyDir: {}
       - name: dind-externals
         emptyDir: {}
+      # Per-pod docker roots for the dind sidecar; reaped by
+      # e2e/runner-dind-cleanup.yaml.
+      - name: dind-docker
+        hostPath:
+          path: /home/runner-dind
+          type: DirectoryOrCreate
       - name: dind-config
         configMap:
           name: dind-registry-mirror

--- a/e2e/runner-dind-cleanup.yaml
+++ b/e2e/runner-dind-cleanup.yaml
@@ -1,0 +1,141 @@
+# Reaper for orphaned per-pod dind docker roots under /home/runner-dind.
+#
+# The arc runner scale sets (argocd/arc-{ci,e2e,beefy}-runners-values.yaml)
+# mount hostPath /home/runner-dind/<POD_NAME> at /var/lib/docker in the
+# dind sidecar so docker image layers land on the 1.8T /home disk with
+# the overlay2 driver, instead of vfs full-copies on the 70G root disk.
+#
+# Runner pods are ephemeral and churn constantly; nothing removes a
+# pod's docker-root subdir when the pod goes away (a preStop hook is not
+# guaranteed to run). This CronJob deletes any subdir that
+#   1. has no matching live pod in arc-runners, AND
+#   2. is older than 10 minutes (grace window so we never race a pod
+#      scheduled between the API snapshot and the sweep).
+#
+# Fail-safe: `set -euo pipefail` means an API/auth failure aborts the
+# run before anything is deleted.
+#
+# Image: ak-runner-rust is used because it is already pulled on the node
+# and ships curl + jq (verified 2026-06-12). The pod runs privileged so
+# SELinux lets it remove files created by the privileged dind sidecar.
+#
+# Apply with:
+#   kubectl apply -f e2e/runner-dind-cleanup.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runner-dind-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/part-of: artifact-keeper
+    app.kubernetes.io/component: runner-dind-cleanup
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: runner-dind-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/part-of: artifact-keeper
+    app.kubernetes.io/component: runner-dind-cleanup
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: runner-dind-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/part-of: artifact-keeper
+    app.kubernetes.io/component: runner-dind-cleanup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: runner-dind-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: runner-dind-cleanup
+    namespace: arc-runners
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: runner-dind-cleanup
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/part-of: artifact-keeper
+    app.kubernetes.io/component: runner-dind-cleanup
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: artifact-keeper
+            app.kubernetes.io/component: runner-dind-cleanup
+        spec:
+          serviceAccountName: runner-dind-cleanup
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: ghcr-pull-secret
+          containers:
+            - name: cleanup
+              image: ghcr.io/artifact-keeper/ak-runner-rust:latest
+              securityContext:
+                runAsUser: 0
+                # privileged so SELinux permits deleting files written by
+                # the privileged dind sidecars.
+                privileged: true
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  SA=/var/run/secrets/kubernetes.io/serviceaccount
+                  live=$(curl -sSf --cacert "$SA/ca.crt" \
+                    -H "Authorization: Bearer $(cat "$SA/token")" \
+                    "https://kubernetes.default.svc/api/v1/namespaces/arc-runners/pods" \
+                    | jq -r '.items[].metadata.name')
+                  now=$(date +%s)
+                  reaped=0
+                  for dir in /runner-dind/*/; do
+                    [ -d "$dir" ] || continue
+                    name=$(basename "$dir")
+                    if grep -qxF "$name" <<<"$live"; then
+                      continue
+                    fi
+                    age=$(( now - $(stat -c %Y "$dir") ))
+                    if [ "$age" -lt 600 ]; then
+                      echo "skipping $name: only ${age}s old (grace window)"
+                      continue
+                    fi
+                    echo "reaping orphaned dind root: $name (age ${age}s)"
+                    rm -rf --one-file-system "/runner-dind/$name"
+                    reaped=$((reaped + 1))
+                  done
+                  echo "done; reaped $reaped orphaned dir(s)"
+              volumeMounts:
+                - name: runner-dind
+                  mountPath: /runner-dind
+          volumes:
+            - name: runner-dind
+              hostPath:
+                path: /home/runner-dind
+                type: DirectoryOrCreate


### PR DESCRIPTION
## Problem

The dind sidecars in all three runner scale sets run `dockerd --storage-driver=vfs` with `/var/lib/docker` unmounted. Every image layer is a **full directory copy** (vfs) landing in the container's writable layer under the crio graph root on the **70G root disk** (~25G free). With `maxRunners: 20` on ak-ci-runners doing concurrent docker builds, this can exhaust the root disk and trigger kubelet disk-pressure eviction of **prod pods** on the rocky node.

## Fix

For ak-ci-runners, ak-e2e-runners, and ak-beefy-runners:

- Mount hostPath `/home/runner-dind` at `/var/lib/docker` with `subPathExpr: $(POD_NAME)` — per-pod isolation, since concurrent dockerds cannot share a docker root. `/home` is 1.8T xfs, `ftype=1` (d_type OK for overlay2).
- Switch dockerd to `--storage-driver=overlay2`. vfs was only required because `/var/lib/docker` previously sat on the crio overlay layer and the RHEL 8.10 4.18 kernel forbids overlay-on-overlay. On a plain xfs directory overlay2 works — verified with a manual overlay mount + copy-up test on `/home` on the node.
- New `e2e/runner-dind-cleanup.yaml`: CronJob (every 15 min, `concurrencyPolicy: Forbid`) reaping `/home/runner-dind` subdirs that have **no matching live pod** in arc-runners AND are **older than 10 min** (grace window). Ephemeral runner pods churn constantly and preStop hooks are not guaranteed to run. Fail-safe: `set -euo pipefail` aborts before any deletion if the API call fails. Uses ak-runner-rust (already on the node, ships curl+jq) with a dedicated SA limited to `pods get/list`.

Permission note (lesson from the SCCACHE_ERROR_LOG outage): the `DirectoryOrCreate` hostPath is root:755, but dockerd runs as root in a privileged container, so it's writable.

## Why not emptyDir + overlay2

emptyDir lives under `/var/lib/kubelet/pods` — still the root disk — and a `sizeLimit` breach evicts the pod mid-job. The hostPath approach moves all heavy build I/O onto the 1.4T-free /home disk.

## Depends on / includes PR #163

⚠️ This branch is based on `fix/sccache-cache-size` (#163), which is **live in prod as helm revision 26** of ak-ci-runners. It includes those commits (SCCACHE_CACHE_SIZE=50G, SCCACHE_ERROR_LOG into the 777 subdir). Merge #163 first or merge this PR which carries both. A values file based on main would revert the sccache fix and re-break every compile job.

## Validation

- `helm upgrade --dry-run=server` with chart **0.13.1** renders cleanly (overlay2 args, POD_NAME downward API env, subPathExpr mount, hostPath volume, sccache env intact).
- overlayfs mount + copy-up tested directly on /home (xfs ftype=1) on the rocky node.
- End-to-end verification (runner pod, `docker info`, in-pod `docker build`, layer location on /home, `sccache --show-stats`) performed after deploy — evidence in PR comments / ops log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)