### PR TITLE
fix(mesh-values): high-entropy JWT secrets for the #1829 startup gate

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --target-branch main --charts charts/artifact-keeper/
 
       - name: Run helm lint
-        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test
+        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f
 
   template-validation:
     name: "Template & Validate (${{ matrix.variant }})"
@@ -53,11 +53,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
           - variant: mesh-main
@@ -112,11 +112,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
     steps:

--- a/charts/artifact-keeper/ci/test-values.yaml
+++ b/charts/artifact-keeper/ci/test-values.yaml
@@ -95,6 +95,6 @@ externalSecrets:
   enabled: false
 
 secrets:
-  jwtSecret: "ci-test-jwt-secret"
+  jwtSecret: "ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7"
   s3AccessKey: "ci-test-access"
   s3SecretKey: "ci-test-secret"

--- a/charts/artifact-keeper/values-mesh-main.yaml
+++ b/charts/artifact-keeper/values-mesh-main.yaml
@@ -108,7 +108,7 @@ ingress:
   enabled: false
 
 secrets:
-  jwtSecret: "mesh-test-jwt-main"
+  jwtSecret: "ak-mesh-main-nonprod-Bdr1bpjKknqKzQXURmY5ol1YXuja72FNvf80YHjjyS6osgyx"
 
 networkPolicy:
   enabled: false

--- a/charts/artifact-keeper/values-mesh-peer.yaml
+++ b/charts/artifact-keeper/values-mesh-peer.yaml
@@ -92,7 +92,7 @@ ingress:
   enabled: false
 
 secrets:
-  jwtSecret: "mesh-test-jwt-peer"
+  jwtSecret: "ak-mesh-peer-nonprod-qAAoih6jbxgaAFm4GMOC5Jc5iYTUV9YutPgl9v8hMqDI4JMy"
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
## Problem
The backend (artifact-keeper#1829) rejects low-entropy JWT secrets at startup in all environments (needs ≥32 chars and ≥16 distinct chars). The mesh overlays use `mesh-test-jwt-main` / `mesh-test-jwt-peer` (18 chars, 10–11 distinct), so the mesh backends crash-loop with `JWT_SECRET is unsuitable: low entropy` and the release-gate **mesh-tests** job fails.

## Fix
Replace both with high-entropy, clearly non-production test secrets (distinct main vs peer preserved). Companion fix for the single-instance test overlays is in artifact-keeper-test#224.