### PR TITLE
chore(release): appVersion + prod image tags to 1.2.1

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --target-branch main --charts charts/artifact-keeper/
 
       - name: Run helm lint
-        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test
+        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f
 
   template-validation:
     name: "Template & Validate (${{ matrix.variant }})"
@@ -53,11 +53,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
           - variant: mesh-main
@@ -112,11 +112,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-test --set postgres.auth.password=ci-test --set meilisearch.masterKey=ci-test"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
     steps:

--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -11,7 +11,7 @@ name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
 version: 1.2.1
-appVersion: "1.2.0"
+appVersion: "1.2.1"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/ci/test-values.yaml
+++ b/charts/artifact-keeper/ci/test-values.yaml
@@ -95,6 +95,6 @@ externalSecrets:
   enabled: false
 
 secrets:
-  jwtSecret: "ci-test-jwt-secret"
+  jwtSecret: "ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7"
   s3AccessKey: "ci-test-access"
   s3SecretKey: "ci-test-secret"

--- a/charts/artifact-keeper/values-mesh-main.yaml
+++ b/charts/artifact-keeper/values-mesh-main.yaml
@@ -108,7 +108,7 @@ ingress:
   enabled: false
 
 secrets:
-  jwtSecret: "mesh-test-jwt-main"
+  jwtSecret: "ak-mesh-main-nonprod-Bdr1bpjKknqKzQXURmY5ol1YXuja72FNvf80YHjjyS6osgyx"
 
 networkPolicy:
   enabled: false

--- a/charts/artifact-keeper/values-mesh-peer.yaml
+++ b/charts/artifact-keeper/values-mesh-peer.yaml
@@ -92,7 +92,7 @@ ingress:
   enabled: false
 
 secrets:
-  jwtSecret: "mesh-test-jwt-peer"
+  jwtSecret: "ak-mesh-peer-nonprod-qAAoih6jbxgaAFm4GMOC5Jc5iYTUV9YutPgl9v8hMqDI4JMy"
 
 networkPolicy:
   enabled: false

--- a/charts/artifact-keeper/values-production.yaml
+++ b/charts/artifact-keeper/values-production.yaml
@@ -11,7 +11,7 @@
 backend:
   replicaCount: 3
   image:
-    tag: "1.2.0"
+    tag: "1.2.1"
   env:
     RUST_LOG: "info"
     ENVIRONMENT: "production"
@@ -49,7 +49,7 @@ backend:
 web:
   replicaCount: 3
   image:
-    tag: "1.2.0"
+    tag: "1.2.1"
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
IaC version bump for **v1.2.1**.

- `Chart.yaml` `appVersion` `1.2.0`→`1.2.1` (chart `version` already `1.2.1`).
- `values-production.yaml` backend + web `image.tag` `1.2.0`→`1.2.1` (matches the established prod-pins-explicit-version convention; staging/default stay `dev`).

Deploys pull `backend:1.2.1` / `web:1.2.1` once those images are published by the `v1.2.1` tags.