### PR TITLE
chore(release): bump chart to 1.2.2

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.2.1
-appVersion: "1.2.0"
+version: 1.2.2
+appVersion: "1.2.2"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.2](https://img.shields.io/badge/AppVersion-1.2.2-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
Bumps the Helm chart to 1.2.2 for the 1.2.2 application release.

- `version` 1.2.1 -> 1.2.2 (chart version)
- `appVersion` 1.2.0 -> 1.2.2 (was lagging a release; drives the default image tag for components that inherit `.Chart.AppVersion`)
- README.md regenerated via helm-docs 1.14.2

The backend:1.2.2 and web:1.2.2 images are published on both ghcr.io and docker.io, so the image-reference gate will resolve.

Closes #173