### PR TITLE
feat(chart): deploy in-house Trivy scanner-adapter (#185)

### DIFF
--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -103,6 +103,7 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | gke.healthCheckPolicies.enabled | bool | `false` | Render a `networking.gke.io/v1` HealthCheckPolicy per Service so a GKE Gateway BackendService probes the app's real health path instead of `/` (which backend and DependencyTrack return 404 for). Leave disabled on non-GKE installs and on plain Ingress-based GKE. |
 | global.affinity | object | `{}` |  |
 | global.imagePullPolicy | string | `"Always"` |  |
+| global.imagePullSecrets | list | `[]` | Image pull secrets applied to workloads that honor them (currently the scanner-adapter). Leave empty for public images. |
 | global.imageRegistry | string | `"ghcr.io/artifact-keeper"` |  |
 | global.nodeSelector | object | `{}` |  |
 | global.storageClass | string | `"standard"` |  |
@@ -125,6 +126,11 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | opensearch.tolerations | list | `[]` | Per-component scheduling (overrides global) |
 | postgres | object | `{"affinity":{},"auth":{"database":"artifact_registry","password":"","username":"registry"},"containerSecurityContext":{},"enabled":true,"image":{"repository":"postgres","tag":"16-alpine"},"initDb":{"enabled":true},"nodeSelector":{},"persistence":{"size":"20Gi","storageClass":""},"podSecurityContext":{"fsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1","ephemeral-storage":"512Mi","memory":"1Gi"},"requests":{"cpu":"250m","ephemeral-storage":"128Mi","memory":"256Mi"}},"tolerations":[],"topologySpreadConstraints":[]}` | PostgreSQL (in-cluster, disable for external/RDS) For production, set postgres.enabled=false and configure externalDatabase to point at a managed database (RDS, Cloud SQL, etc.). The in-cluster instance is suitable for dev/testing only. |
 | postgres.tolerations | list | `[]` | Per-component scheduling (overrides global) |
+| scannerAdapter | object | `{"affinity":{},"cacheSizeLimit":"2Gi","containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"enabled":true,"env":{"SCANNER_TRIVY_INSECURE":"true"},"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter","tag":"dev"},"nodeSelector":{},"podSecurityContext":{"fsGroup":10000,"runAsNonRoot":true,"runAsUser":10000},"resources":{"limits":{"cpu":"1","ephemeral-storage":"2Gi","memory":"1Gi"},"requests":{"cpu":"100m","ephemeral-storage":"128Mi","memory":"128Mi"}},"tmpSizeLimit":"1Gi","tolerations":[],"topologySpreadConstraints":[]}` | In-house Trivy scanner-adapter Stateless Harbor-protocol scanner-adapter (image artifact-keeper-scanner-adapter) that the backend calls over HTTP via TRIVY_ADAPTER_URL for container-image Trivy scans. It pulls the target image from the AK registry per request and runs Trivy in-process, so it needs no Redis and no persistent storage — a single replica is fine. The image is multi-arch (amd64 + arm64), so there is no arch-pinned nodeSelector; leave it enabled on arm64 clusters too. Default enabled: true (recommended for amd64 and supported on arm64). This is separate from the `trivy` server above, which stays on TRIVY_URL for the fs/incus scan path. |
+| scannerAdapter.cacheSizeLimit | string | `"2Gi"` | Writable scratch for image-layer extraction and the Trivy DB cache. emptyDir (no PVC) because the adapter is stateless. |
+| scannerAdapter.env | object | `{"SCANNER_TRIVY_INSECURE":"true"}` | Extra environment for the adapter. SCANNER_TRIVY_INSECURE defaults to "true" because the adapter reaches the AK registry over the plain-HTTP in-cluster Service endpoint; set to "false" if the adapter pulls from a TLS-terminated registry it can verify. |
+| scannerAdapter.image.tag | string | `"dev"` | "dev" is a floating tag built from main (same convention as the backend/web/edge images above). Leave this empty ("") to track the chart appVersion instead — the deployment renders the tag as `tag | default .Chart.AppVersion`, so release overlays that omit the tag inherit appVersion and cut-time bumps re-pin the adapter in lockstep. |
+| scannerAdapter.tolerations | list | `[]` | Per-component scheduling (overrides global). Do NOT arch-pin here; the image is multi-arch. |
 | secrets | object | `{"jwtSecret":"","migrationEncryptionKey":"","s3AccessKey":"","s3SecretKey":"","smtpPassword":""}` | Secrets These are development defaults. For production, override via --set or use existingSecret references. Never commit real credentials here. |
 | serviceMonitor | object | `{"enabled":false,"interval":"30s","scrapeTimeout":"10s"}` | Prometheus ServiceMonitor |
 | trivy | object | `{"affinity":{},"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"db":{"javaRepository":"","preseed":{"enabled":false},"repository":"","skipUpdate":false},"enabled":true,"image":{"repository":"aquasec/trivy","tag":"0.62.1"},"initContainerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"nodeSelector":{},"persistence":{"size":"5Gi","storageClass":""},"podSecurityContext":{"fsGroup":10000,"runAsNonRoot":true,"runAsUser":10000},"resources":{"limits":{"cpu":"1","ephemeral-storage":"1Gi","memory":"2Gi"},"requests":{"cpu":"250m","ephemeral-storage":"128Mi","memory":"256Mi"}},"tolerations":[],"topologySpreadConstraints":[]}` | Trivy vulnerability scanner Runs as a persistent server that the backend calls for image/SBOM scans. Uses a PVC for its vulnerability database cache. The deployment uses Recreate strategy because the cache directory uses a file lock that prevents concurrent access from two pods. |
@@ -212,7 +218,8 @@ The chart deploys the following components:
 | **Edge** | Edge replication service for distributed deployments | Disabled |
 | **PostgreSQL** | In-cluster database (disable for external/managed DB) | Enabled |
 | **OpenSearch** | Full-text search engine for artifact discovery | Enabled |
-| **Trivy** | Vulnerability scanner for container images and SBOMs | Enabled |
+| **Trivy** | Vulnerability scanner for container images and SBOMs (fs/incus path via `TRIVY_URL`) | Enabled |
+| **Scanner-adapter** | In-house Harbor scanner-adapter for container-image Trivy scans (`TRIVY_ADAPTER_URL`); stateless, multi-arch, no PVC | Enabled |
 | **DependencyTrack** | SBOM analysis platform for license and vulnerability correlation | Enabled |
 
 ### Component Diagram
@@ -226,6 +233,8 @@ Ingress
 Backend --> PostgreSQL (port 5432)
 Backend --> OpenSearch (port 9200)
 Backend --> Trivy (port 8090)
+Backend --> Scanner-adapter (port 8090)
+Scanner-adapter --> Backend registry (pull target images)
 Backend --> DependencyTrack (port 8080)
 ```
 

--- a/charts/artifact-keeper/README.md.gotmpl
+++ b/charts/artifact-keeper/README.md.gotmpl
@@ -155,7 +155,8 @@ The chart deploys the following components:
 | **Edge** | Edge replication service for distributed deployments | Disabled |
 | **PostgreSQL** | In-cluster database (disable for external/managed DB) | Enabled |
 | **OpenSearch** | Full-text search engine for artifact discovery | Enabled |
-| **Trivy** | Vulnerability scanner for container images and SBOMs | Enabled |
+| **Trivy** | Vulnerability scanner for container images and SBOMs (fs/incus path via `TRIVY_URL`) | Enabled |
+| **Scanner-adapter** | In-house Harbor scanner-adapter for container-image Trivy scans (`TRIVY_ADAPTER_URL`); stateless, multi-arch, no PVC | Enabled |
 | **DependencyTrack** | SBOM analysis platform for license and vulnerability correlation | Enabled |
 
 ### Component Diagram
@@ -169,6 +170,8 @@ Ingress
 Backend --> PostgreSQL (port 5432)
 Backend --> OpenSearch (port 9200)
 Backend --> Trivy (port 8090)
+Backend --> Scanner-adapter (port 8090)
+Scanner-adapter --> Backend registry (pull target images)
 Backend --> DependencyTrack (port 8080)
 ```
 

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -120,6 +120,14 @@ app.kubernetes.io/component: trivy
 {{- end }}
 
 {{/*
+Scanner-adapter selector labels
+*/}}
+{{- define "artifact-keeper.scannerAdapter.selectorLabels" -}}
+{{ include "artifact-keeper.selectorLabels" . }}
+app.kubernetes.io/component: scanner-adapter
+{{- end }}
+
+{{/*
 DependencyTrack selector labels
 */}}
 {{- define "artifact-keeper.dtrack.selectorLabels" -}}

--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -214,6 +214,13 @@ spec:
             - name: SCAN_WORKSPACE_PATH
               value: "/scan-workspace"
             {{- end }}
+            {{- if .Values.scannerAdapter.enabled }}
+            # In-house Harbor scanner-adapter for container-image Trivy scans
+            # (artifact-keeper#2091). Host must match the scanner-adapter Service
+            # name. Leaves TRIVY_URL (fs/incus path) above untouched.
+            - name: TRIVY_ADAPTER_URL
+              value: "http://{{ include "artifact-keeper.fullname" . }}-scanner-adapter:8090"
+            {{- end }}
             {{- if .Values.dependencyTrack.enabled }}
             - name: DEPENDENCY_TRACK_URL
               value: "http://{{ include "artifact-keeper.fullname" . }}-dtrack:8080"

--- a/charts/artifact-keeper/templates/networkpolicy.yaml
+++ b/charts/artifact-keeper/templates/networkpolicy.yaml
@@ -34,6 +34,16 @@ spec:
           protocol: TCP
         - port: {{ .Values.backend.service.grpcPort }}
           protocol: TCP
+    {{- if .Values.scannerAdapter.enabled }}
+    # Scanner-adapter pulls target images from the backend registry endpoint
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ .Values.backend.service.httpPort }}
+          protocol: TCP
+    {{- end }}
     # Allow ingress controller
     - from:
         - namespaceSelector: {}
@@ -78,6 +88,16 @@ spec:
       ports:
         - port: 8090
           protocol: TCP
+    {{- if .Values.scannerAdapter.enabled }}
+    # Scanner-adapter (container-image Trivy scans)
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: 8090
+          protocol: TCP
+    {{- end }}
     # DependencyTrack
     - to:
         - podSelector:
@@ -201,6 +221,51 @@ spec:
     - ports:
         - port: 443
           protocol: TCP
+{{- if .Values.scannerAdapter.enabled }}
+---
+# Scanner-adapter: accept scan requests from backend on 8090; reach the backend
+# registry endpoint to pull target images, plus DNS/HTTPS for the vuln DB.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-scanner-adapter
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "artifact-keeper.backend.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: 8090
+          protocol: TCP
+  egress:
+    # DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Backend registry endpoint (pull target images to scan)
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "artifact-keeper.backend.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ .Values.backend.service.httpPort }}
+          protocol: TCP
+    # HTTPS (Trivy vulnerability DB, external registries)
+    - ports:
+        - port: 443
+          protocol: TCP
+{{- end }}
 ---
 # DependencyTrack: accept traffic from backend and dtrack-init Job
 apiVersion: networking.k8s.io/v1

--- a/charts/artifact-keeper/templates/scanner-adapter-deployment.yaml
+++ b/charts/artifact-keeper/templates/scanner-adapter-deployment.yaml
@@ -70,6 +70,12 @@ spec:
               value: /home/scanner
             - name: TMPDIR
               value: /tmp
+            # The adapter binary defaults to :8080, but the chart wires the
+            # Service, probes, containerPort and TRIVY_ADAPTER_URL all on 8090.
+            # Pin the listen address so the port matches (otherwise the 8090
+            # probes get connection-refused and the pod crash-loops).
+            - name: SCANNER_ADAPTER_ADDR
+              value: ":8090"
             {{- range $key, $value := .Values.scannerAdapter.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/artifact-keeper/templates/scanner-adapter-deployment.yaml
+++ b/charts/artifact-keeper/templates/scanner-adapter-deployment.yaml
@@ -1,0 +1,112 @@
+{{/*
+=============================================================================
+EXAMPLE CONFIGURATION - Getting Started Template
+=============================================================================
+This file is provided as a starting point for deployments. It should be
+reviewed and modified to match your specific infrastructure requirements,
+security policies, and operational needs before use in production.
+=============================================================================
+*/}}
+{{- if .Values.scannerAdapter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-scanner-adapter
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner-adapter
+spec:
+  # Stateless adapter: a single replica is sufficient. The adapter holds no
+  # persistent state (no Redis, no PVC) — it pulls the target image from the
+  # AK registry per request and returns the Trivy result to the backend.
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with (.Values.scannerAdapter.tolerations | default .Values.global.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.scannerAdapter.affinity | default .Values.global.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.scannerAdapter.nodeSelector | default .Values.global.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.scannerAdapter.topologySpreadConstraints | default .Values.global.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: false
+      {{- with .Values.scannerAdapter.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: scanner-adapter
+          # appVersion drives the tag by default (same pattern as backend/web);
+          # the image is multi-arch, so no arch-pinned nodeSelector is needed.
+          image: "{{ .Values.scannerAdapter.image.repository }}:{{ .Values.scannerAdapter.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.scannerAdapter.image.pullPolicy }}
+          {{- with .Values.scannerAdapter.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: HOME
+              value: /home/scanner
+            - name: TMPDIR
+              value: /tmp
+            {{- range $key, $value := .Values.scannerAdapter.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8090
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.scannerAdapter.resources | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: 8090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            tcpSocket:
+              port: 8090
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            # readOnlyRootFilesystem is on, so give the adapter writable scratch
+            # space for image-layer extraction and the Trivy DB cache. Stateless:
+            # emptyDir is fine, no PVC required.
+            - name: cache
+              mountPath: /home/scanner/.cache
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: cache
+          emptyDir:
+            sizeLimit: {{ .Values.scannerAdapter.cacheSizeLimit | default "2Gi" }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.scannerAdapter.tmpSizeLimit | default "1Gi" }}
+{{- end }}

--- a/charts/artifact-keeper/templates/scanner-adapter-service.yaml
+++ b/charts/artifact-keeper/templates/scanner-adapter-service.yaml
@@ -1,0 +1,27 @@
+{{/*
+=============================================================================
+EXAMPLE CONFIGURATION - Getting Started Template
+=============================================================================
+This file is provided as a starting point for deployments. It should be
+reviewed and modified to match your specific infrastructure requirements,
+security policies, and operational needs before use in production.
+=============================================================================
+*/}}
+{{- if .Values.scannerAdapter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-scanner-adapter
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner-adapter
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8090
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "artifact-keeper.scannerAdapter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/artifact-keeper/values-production.yaml
+++ b/charts/artifact-keeper/values-production.yaml
@@ -143,6 +143,16 @@ trivy:
       cpu: "2"
       memory: 4Gi
 
+# In-house Trivy scanner-adapter (container-image scans). Multi-arch, stateless.
+scannerAdapter:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
 dependencyTrack:
   adminPassword: ""
   persistence:

--- a/charts/artifact-keeper/values-smoke.yaml
+++ b/charts/artifact-keeper/values-smoke.yaml
@@ -154,6 +154,25 @@ edge:
 trivy:
   enabled: false
 
+# In-house Trivy scanner-adapter: ENABLED for the release-gate. Unlike the
+# standalone `trivy` server above (heavy DB pull, disabled for smoke), the
+# adapter is the code path the backend actually uses for container-image scans
+# (TRIVY_ADAPTER_URL), so the artifact-keeper-test#237 per-scanner Trivy
+# assertion must exercise it live on the amd64 gate runners before a cut. It is
+# stateless (no PVC, no Redis) and lightweight enough to fit the 4 CPU / 8 Gi
+# namespace alongside backend + web + postgres + opensearch.
+scannerAdapter:
+  enabled: true
+  image:
+    pullPolicy: Always
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 768Mi
+
 # Dependency-Track: 4 GiB+ JVM, multi-minute startup loading the NVD on
 # first boot. Far too heavy for a smoke namespace.
 dependencyTrack:

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -58,6 +58,9 @@ global:
   imageRegistry: ghcr.io/artifact-keeper
   imagePullPolicy: Always
   storageClass: standard
+  # -- Image pull secrets applied to workloads that honor them (currently the
+  # scanner-adapter). Leave empty for public images.
+  imagePullSecrets: []
 
   # -- Scheduling constraints applied to ALL workloads by default.
   # Per-component values (e.g. backend.nodeSelector) override these.
@@ -650,6 +653,63 @@ trivy:
       memory: 2Gi
       ephemeral-storage: 1Gi
   # -- Per-component scheduling (overrides global)
+  tolerations: []
+  affinity: {}
+  nodeSelector: {}
+  topologySpreadConstraints: []
+
+# -- In-house Trivy scanner-adapter
+# Stateless Harbor-protocol scanner-adapter (image
+# artifact-keeper-scanner-adapter) that the backend calls over HTTP via
+# TRIVY_ADAPTER_URL for container-image Trivy scans. It pulls the target image
+# from the AK registry per request and runs Trivy in-process, so it needs no
+# Redis and no persistent storage — a single replica is fine. The image is
+# multi-arch (amd64 + arm64), so there is no arch-pinned nodeSelector; leave it
+# enabled on arm64 clusters too. Default enabled: true (recommended for amd64
+# and supported on arm64). This is separate from the `trivy` server above,
+# which stays on TRIVY_URL for the fs/incus scan path.
+scannerAdapter:
+  enabled: true
+  image:
+    repository: ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter
+    # -- "dev" is a floating tag built from main (same convention as the
+    # backend/web/edge images above). Leave this empty ("") to track the chart
+    # appVersion instead — the deployment renders the tag as
+    # `tag | default .Chart.AppVersion`, so release overlays that omit the tag
+    # inherit appVersion and cut-time bumps re-pin the adapter in lockstep.
+    tag: dev
+    pullPolicy: IfNotPresent
+  # -- Extra environment for the adapter. SCANNER_TRIVY_INSECURE defaults to
+  # "true" because the adapter reaches the AK registry over the plain-HTTP
+  # in-cluster Service endpoint; set to "false" if the adapter pulls from a
+  # TLS-terminated registry it can verify.
+  env:
+    SCANNER_TRIVY_INSECURE: "true"
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # -- Writable scratch for image-layer extraction and the Trivy DB cache.
+  # emptyDir (no PVC) because the adapter is stateless.
+  cacheSizeLimit: 2Gi
+  tmpSizeLimit: 1Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+      ephemeral-storage: 128Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+      ephemeral-storage: 2Gi
+  # -- Per-component scheduling (overrides global). Do NOT arch-pin here; the
+  # image is multi-arch.
   tolerations: []
   affinity: {}
   nodeSelector: {}

--- a/demo/docker-compose.demo.yml
+++ b/demo/docker-compose.demo.yml
@@ -41,6 +41,9 @@ services:
       JWT_SECRET: demo-instance-jwt-secret-not-for-production
       DEMO_MODE: "true"
       TRIVY_URL: http://trivy:8090
+      # In-house Trivy scanner-adapter for container-image scans (backend #2090).
+      # TRIVY_URL above stays for the fs/incus scan path.
+      TRIVY_ADAPTER_URL: http://scanner-adapter:8090
       OPENSCAP_URL: http://openscap:8091
       SCAN_WORKSPACE_PATH: /scan-workspace
       LOG_LEVEL: info
@@ -59,6 +62,19 @@ services:
     volumes:
       - trivy_cache:/root/.cache/trivy
       - scan_workspace:/scan-workspace:ro
+
+  # In-house Harbor scanner-adapter: the backend calls this over
+  # TRIVY_ADAPTER_URL for container-image Trivy scans. Stateless, no Redis, no
+  # persistent storage. Pulls target images from the backend registry, so it
+  # reaches `backend` on the compose network. Multi-arch image.
+  scanner-adapter:
+    image: ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter:${ARTIFACT_KEEPER_VERSION:-latest}
+    environment:
+      # The backend registry endpoint is served over plain HTTP on the compose
+      # network, so allow insecure pulls.
+      SCANNER_TRIVY_INSECURE: "true"
+    depends_on:
+      - backend
 
   openscap:
     image: ghcr.io/artifact-keeper/artifact-keeper-openscap:${ARTIFACT_KEEPER_VERSION:-latest}


### PR DESCRIPTION
Closes #185

Deploy the new in-house Trivy **scanner-adapter** (multi-arch image `artifact-keeper-scanner-adapter`, container port 8090) so container-image Trivy scanning works in real deployments. The backend (artifact-keeper #2090) calls it over HTTP via `TRIVY_ADAPTER_URL`; without this iac wiring the adapter image exists but nothing runs it.

## What changed

### Helm chart (`charts/artifact-keeper/`)
- **New templates** `scanner-adapter-deployment.yaml` + `scanner-adapter-service.yaml`, gated behind `.Values.scannerAdapter.enabled`. Mirrors the existing component conventions (common/selector labels, per-component + global scheduling, securityContext, resources, guarded `imagePullSecrets`). Stateless: no Redis, no PVC — a single replica with `emptyDir` scratch/cache and `readOnlyRootFilesystem`. Service exposes port **8090**.
- **Image** renders as `{{ .Values.scannerAdapter.image.repository }}:{{ .Values.scannerAdapter.image.tag | default .Chart.AppVersion }}` — the same appVersion-drives-tag pattern as backend/web/edge. Base `values.yaml` pins `tag: dev` (floating main tag, matching the other components) so the `verify-image-references` CI gate probes an image that exists; overlays that set an empty tag inherit `appVersion`, and the cut-time bump re-pins the adapter in lockstep.
- **No arch-pinned nodeSelector** — the image is multi-arch (amd64 + arm64).
- **`scannerAdapter:` values block** added (enabled, image, `SCANNER_TRIVY_INSECURE`, securityContext, resources, cache/tmp sizes, scheduling) + `global.imagePullSecrets`.
- **Backend Deployment**: when `scannerAdapter.enabled`, sets `TRIVY_ADAPTER_URL=http://<release>-scanner-adapter:8090` (matches the Service name). Existing `TRIVY_URL` (fs/incus path) left untouched.
- **NetworkPolicy** (rendered when `networkPolicy.enabled`): backend egress to the adapter on 8090, backend ingress from the adapter on the registry http port, and a dedicated adapter policy (ingress from backend on 8090; egress DNS + backend registry + 443). All gated on `scannerAdapter.enabled`.
- **helm-docs README** regenerated (arm64 helm-docs 1.14.2), plus the prose component table + architecture diagram.

### Default for `enabled`: **`true`**
Recommended on amd64 clusters, and the multi-arch image means arm64 nodes schedule it too, so it can stay on everywhere. Disable with `--set scannerAdapter.enabled=false`.

### Demo compose (`demo/docker-compose.demo.yml`)
- Added a `scanner-adapter` service (`ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter:${ARTIFACT_KEEPER_VERSION:-latest}`, `SCANNER_TRIVY_INSECURE=true`, port 8090) and set `TRIVY_ADAPTER_URL=http://scanner-adapter:8090` on the backend. The existing `trivy` server stays for the fs/incus `TRIVY_URL` path.

### Release-gate
- The release-gate deploy uses `values-smoke.yaml`, which now **enables** `scannerAdapter` (it is stateless/lightweight, unlike the heavy standalone `trivy` server that stays disabled for smoke). This makes the artifact-keeper-test **#237** per-scanner Trivy assertion validate the real path on the amd64 gate runners before a cut.

### Chart version
Left at `1.2.3` (matching `appVersion`) — this rides the in-progress 1.2.3 cut and the version bump is performed by the dedicated `chore(release)` PR at cut time. The `version-check` CI job only warns on an unbumped version.

## Validation (no cluster)
`helm lint` passes. `helm template` with `scannerAdapter.enabled=true` renders 3 extra objects (Deployment + Service + NetworkPolicy, all named `<release>-scanner-adapter`) and injects `TRIVY_ADAPTER_URL=http://artifact-keeper-scanner-adapter:8090` into the backend — the URL host exactly matches the Service name. With `=false`, all adapter objects and the backend env var disappear while `TRIVY_URL` is retained. All CI variants (default/production/staging/smoke/mesh-main/mesh-peer/registry-cache) render, and every rendered doc parses with 0 empty documents.

Rendered evidence is in the PR discussion below / the commit.
