### PR TITLE
fix(ci): cap ak-ci-runners maxRunners + raise requests to stop node overcommit

### DIFF
--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -52,7 +52,11 @@ githubConfigSecret: "github-token-secret"
 runnerScaleSetName: "ak-ci-runners"
 
 minRunners: 0
-maxRunners: 20
+maxRunners: 6
+# Capped 20->6 (#187): scheduler packs by requests, but each runner can use up
+# to its 16Gi limit under a clippy burst. At 20 that was 20*16=320Gi >> the ~125Gi
+# node -> memory exhaustion wedged the whole node (kubelet+sshd unresponsive). 6*16=96Gi
+# stays safely under 125Gi. Raise requests (8Gi/4cpu) too so scheduling reserves honestly.
 
 template:
   spec:
@@ -83,8 +87,8 @@ template:
             value: "0"
         resources:
           requests:
-            cpu: "2"
-            memory: "4Gi"
+            cpu: "4"
+            memory: "8Gi"
           # limits raised 8Gi->16Gi / cpu 4->8 (#2062): clippy-driver on the
           # backend lib-test crate uses ~2-3x rustc's RSS, so even 2 parallel
           # drivers OOM-killed (signal 9) the 8Gi pod, forcing admin-merges.


### PR DESCRIPTION
Closes #187

Prevents a CI burst from wedging the single runner node (the 2026-07-01 incident).

**Change** (`argocd/arc-ci-runners-values.yaml`):
- `maxRunners` 20 -> 6 (worst case 6x16Gi = 96Gi < ~125Gi allocatable)
- requests cpu 2 -> 4, memory 4Gi -> 8Gi (scheduler reserves realistically)
- limits unchanged (8cpu / 16Gi — clippy needs it)

**Root cause:** scheduler packs by requests (4Gi) but pods can use up to the 16Gi limit; at maxRunners=20 a concurrent clippy burst demanded up to 320Gi on a ~125Gi node -> memory exhaustion -> node thrash (kubelet + sshd unresponsive), jobs stuck QUEUED.

**Already applied live** on the node via `helm upgrade ak-ci-runners ... --version 0.13.1` (rev 29) to recover CI; this PR syncs git so the checkout stops drifting.

Node-level follow-up (separate): consider disabling swap so the node OOM-kills one pod instead of thrashing the whole box.