### PR TITLE
fix(ci-runners): cap per-runner build/test parallelism to stop node wedges (#192)

### DIFF
--- a/argocd/arc-ci-runners-values.yaml
+++ b/argocd/arc-ci-runners-values.yaml
@@ -85,6 +85,30 @@ template:
             value: /cache/npm
           - name: SCCACHE_IDLE_TIMEOUT
             value: "0"
+          # Without an explicit size sccache defaults to 10 GiB and evicts
+          # continuously; /home has ample space. (Reconciled from live rocky
+          # config, which had drifted ahead of git — iac#192.)
+          - name: SCCACHE_CACHE_SIZE
+            value: "50G"
+          # Must live under a dir init-cache chmods to 777; an unwritable
+          # SCCACHE_ERROR_LOG kills the sccache server at startup and fails
+          # every compile job (2026-06-12 outage). Keep it set.
+          - name: SCCACHE_ERROR_LOG
+            value: /cache/sccache/sccache-error.log
+          # PARALLELISM CAP (iac#192, 2026-07-02): cargo/rustc/nextest read the
+          # HOST core count (88) and spawn that many jobs, IGNORING this pod's
+          # 8-CPU cgroup limit — so each runner launches ~88 threads that the
+          # cgroup throttles onto 8 CPUs. N runners => load ~= maxRunners x 88,
+          # which wedged the node twice (load 462 at 6 runners, 1420 peak,
+          # SSH-banner-timeout). Pinning build/test parallelism to the CPU
+          # limit makes load ~= maxRunners x 8, so maxRunners is a throughput
+          # knob again, not a wedge fuse.
+          - name: CARGO_BUILD_JOBS
+            value: "8"
+          - name: RUST_TEST_THREADS
+            value: "8"
+          - name: NEXTEST_TEST_THREADS
+            value: "8"
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
Closes #192

## Root cause
The ak-ci-runners pods set `limits.cpu: 8` but nothing tells the Rust toolchain about it. cargo/rustc/nextest read the **host** core count (88) and spawn that many jobs; the cgroup then throttles all ~88 threads onto 8 CPUs, producing a huge run-queue. With N runners that's **load ≈ maxRunners × 88**, which wedged rocky twice (load 462 at 6 runners, 1420 peak, SSH-banner-timeout → reboot). `maxRunners` was only ever a blunt proxy for total compile threads.

## Fix
Pin per-runner parallelism to the CPU limit via runner-container env:
- `CARGO_BUILD_JOBS=8`, `RUST_TEST_THREADS=8`, `NEXTEST_TEST_THREADS=8`

Now **load ≈ maxRunners × 8** (~48 at 6 runners on 88 cores), so maxRunners is a throughput knob again, not a wedge fuse. Applied live on rocky 2026-07-02 (helm rev 36); this commits it to source-of-truth.

Also reconciles `SCCACHE_CACHE_SIZE=50G` and `SCCACHE_ERROR_LOG` into git — they had drifted ahead on the live node, and the latter's absence previously caused a compile-job outage, so a future ArgoCD sync must not drop them.

## Follow-ups (not in this PR)
- Apply the same caps to `ak-beefy-runners` and `ak-e2e-runners` values (identical latent issue).
- dind `--storage-driver=vfs` → overlay2/fuse-overlayfs (image-build I/O).
- The deeper problem is node over-tenancy (rocky runs prod+dev+mesh+peers+CI on one box); tracked separately.