### PR TITLE
Cap build/test parallelism on beefy + e2e runner pools (iac#192)

### DIFF
--- a/argocd/arc-beefy-runners-values.yaml
+++ b/argocd/arc-beefy-runners-values.yaml
@@ -76,6 +76,19 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: "120"
+          # PARALLELISM CAP (iac#192): cargo/rustc/nextest read the HOST core
+          # count (88) and spawn that many jobs, IGNORING this pod's 8-CPU cgroup
+          # limit — so each runner launches ~88 threads the cgroup throttles onto
+          # 8 CPUs. N runners => load ~= maxRunners x 88, which wedged rocky
+          # (SSH-banner-timeout). ak-ci-runners got this cap in helm rev 37; the
+          # beefy pool was the last uncapped one. Pin to the 8-CPU limit so load
+          # ~= maxRunners x 8 and maxRunners stays a throughput knob, not a fuse.
+          - name: CARGO_BUILD_JOBS
+            value: "8"
+          - name: RUST_TEST_THREADS
+            value: "8"
+          - name: NEXTEST_TEST_THREADS
+            value: "8"
         volumeMounts:
           - name: work
             mountPath: /home/runner/_work

--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -55,6 +55,17 @@ template:
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
+          # PARALLELISM CAP (iac#192): cargo/rustc/nextest read the HOST core
+          # count (88), IGNORING this pod's 4-CPU cgroup limit, spawning ~88
+          # throttled threads per runner => load ~= maxRunners x 88 and rocky
+          # wedged. ak-ci-runners got this in helm rev 37; pin the e2e pool to
+          # its 4-CPU limit so load ~= maxRunners x 4.
+          - name: CARGO_BUILD_JOBS
+            value: "4"
+          - name: RUST_TEST_THREADS
+            value: "4"
+          - name: NEXTEST_TEST_THREADS
+            value: "4"
         volumeMounts:
           - name: work
             mountPath: /home/runner/_work


### PR DESCRIPTION
Closes #192.

## What
Pin \`CARGO_BUILD_JOBS\` / \`RUST_TEST_THREADS\` / \`NEXTEST_TEST_THREADS\` on the two remaining uncapped runner pools:
- **ak-beefy-runners** -> 8 (its 8-CPU limit)
- **ak-e2e-runners** -> 4 (its 4-CPU limit)

## Why
cargo/rustc/nextest read the *host* core count (88) and spawn that many jobs, ignoring each runner pod's cgroup CPU limit. Result: load scaled as `maxRunners x 88` and wedged rocky (SSH-banner-timeout) twice. `ak-ci-runners` already got these caps (helm rev 37); beefy and e2e were the last uncapped pools. With the caps, load = `maxRunners x jobs`, so `maxRunners` is a throughput knob again rather than a wedge fuse.

## Scope
Values-only; no chart/template changes. Apply on next `helm upgrade` of each scale set (or ArgoCD sync).