### PR TITLE
Add CI self-test namespace TTL sweeper (backstop for artifact-keeper#2141)

### DIFF
--- a/argocd/arc-beefy-runners-values.yaml
+++ b/argocd/arc-beefy-runners-values.yaml
@@ -76,6 +76,19 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: "120"
+          # PARALLELISM CAP (iac#192): cargo/rustc/nextest read the HOST core
+          # count (88) and spawn that many jobs, IGNORING this pod's 8-CPU cgroup
+          # limit — so each runner launches ~88 threads the cgroup throttles onto
+          # 8 CPUs. N runners => load ~= maxRunners x 88, which wedged rocky
+          # (SSH-banner-timeout). ak-ci-runners got this cap in helm rev 37; the
+          # beefy pool was the last uncapped one. Pin to the 8-CPU limit so load
+          # ~= maxRunners x 8 and maxRunners stays a throughput knob, not a fuse.
+          - name: CARGO_BUILD_JOBS
+            value: "8"
+          - name: RUST_TEST_THREADS
+            value: "8"
+          - name: NEXTEST_TEST_THREADS
+            value: "8"
         volumeMounts:
           - name: work
             mountPath: /home/runner/_work

--- a/argocd/arc-e2e-runners-values.yaml
+++ b/argocd/arc-e2e-runners-values.yaml
@@ -55,6 +55,17 @@ template:
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
+          # PARALLELISM CAP (iac#192): cargo/rustc/nextest read the HOST core
+          # count (88), IGNORING this pod's 4-CPU cgroup limit, spawning ~88
+          # throttled threads per runner => load ~= maxRunners x 88 and rocky
+          # wedged. ak-ci-runners got this in helm rev 37; pin the e2e pool to
+          # its 4-CPU limit so load ~= maxRunners x 4.
+          - name: CARGO_BUILD_JOBS
+            value: "4"
+          - name: RUST_TEST_THREADS
+            value: "4"
+          - name: NEXTEST_TEST_THREADS
+            value: "4"
         volumeMounts:
           - name: work
             mountPath: /home/runner/_work

--- a/argocd/ci-namespace-sweeper-application.yaml
+++ b/argocd/ci-namespace-sweeper-application.yaml
@@ -1,0 +1,42 @@
+# ArgoCD Application for the CI self-test namespace TTL sweeper
+# (backstop for artifact-keeper/artifact-keeper#2141).
+#
+# Deploys ci-maintenance/namespace-sweeper.yaml (a CronJob + its scoped RBAC)
+# onto the CI/CD runner cluster (rocky). selfHeal + prune are ON: this is
+# pure infra hygiene with a tiny, cheap-to-reconcile footprint (one CronJob),
+# so it should survive cluster churn without an operator babysitting it —
+# unlike the crash-looping app stacks that made ArgoCD reconcile thrash.
+#
+# Bootstrap (once, with kubectl context on the runner cluster):
+#   kubectl apply -f argocd/ci-namespace-sweeper-application.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ci-ns-sweeper
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: ak-infra
+    ak-infra-role: ci-maintenance
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/artifact-keeper/artifact-keeper-iac
+    targetRevision: main
+    path: ci-maintenance
+    directory:
+      recurse: false
+  destination:
+    server: https://kubernetes.default.svc
+    # The manifest bundle declares its own ci-maintenance namespace; ArgoCD
+    # applies cluster-scoped resources (ClusterRole/Binding) regardless of
+    # this default.
+    namespace: ci-maintenance
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/ci-maintenance/namespace-sweeper.yaml
+++ b/ci-maintenance/namespace-sweeper.yaml
@@ -1,0 +1,168 @@
+# CI self-test namespace TTL sweeper (backstop for artifact-keeper/artifact-keeper#2141).
+#
+# The ephemeral per-run namespaces created by the self-test / smoke-test CI
+# jobs (smoke-self-crash-*, smoke-self-pull-*, test-self-trivy-zero-*,
+# test-self-clean-fixture-*, suffixed with the CI run id) are NOT reliably
+# torn down when their job ends — the in-job cleanup does not fire on the
+# crash / cancel / self-crash paths, and the creators are split across the
+# backend AND web repos. Left alone they accumulate for weeks (10 namespaces
+# / 48 pods / ~30-40Gi of OpenSearch JVM RSS observed on rocky), slowly
+# exhausting node memory and compounding the CPU-load wedge risk.
+#
+# This CronJob is a CREATOR-AGNOSTIC backstop: hourly it deletes any
+# namespace whose name starts with an approved CI-test prefix AND is older
+# than TTL_HOURS. It is deliberately conservative — see the safety guards in
+# the script. A per-job always() cleanup step in the creating workflows is a
+# complementary hardening tracked separately; this backstop stands on its own.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ci-maintenance
+  labels:
+    app.kubernetes.io/part-of: ak-infra
+    ak-infra-role: ci-maintenance
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-ns-sweeper
+  namespace: ci-maintenance
+---
+# Cluster-scoped: listing + deleting namespaces is inherently cluster-wide.
+# The blast radius is constrained in the SCRIPT (prefix allowlist + hard
+# denylist), not by RBAC, because namespace verbs cannot be name-scoped.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ci-ns-sweeper
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-ns-sweeper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-ns-sweeper
+subjects:
+  - kind: ServiceAccount
+    name: ci-ns-sweeper
+    namespace: ci-maintenance
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ci-ns-sweeper
+  namespace: ci-maintenance
+  labels:
+    app.kubernetes.io/part-of: ak-infra
+    ak-infra-role: ci-maintenance
+spec:
+  # Hourly. A leaked namespace lives at most ~TTL_HOURS + 1h before reclaim,
+  # vs the weeks observed before this existed.
+  schedule: "17 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      # Give up (don't retry-storm) if a run wedges; the next hour retries.
+      activeDeadlineSeconds: 600
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/part-of: ak-infra
+            ak-infra-role: ci-maintenance
+        spec:
+          serviceAccountName: ci-ns-sweeper
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sweeper
+              # Debian-based (GNU date for RFC3339 parsing + a POSIX shell).
+              image: docker.io/bitnami/kubectl:1.31
+              imagePullPolicy: IfNotPresent
+              env:
+                # A namespace must match one of these prefixes to be eligible.
+                - name: SWEEP_PREFIXES
+                  value: "smoke-self- test-self-"
+                # ...and be at least this old. Longest e2e run is well under
+                # an hour; 4h is a wide safety margin against sweeping a live
+                # job's namespace.
+                - name: TTL_HOURS
+                  value: "4"
+                # Belt-and-suspenders: never touch these even if a prefix
+                # somehow matched. Substring match against the whole name.
+                - name: PROTECT_SUBSTRINGS
+                  value: "prod staging artifact-keeper artifactkeeper mesh peer argocd arc- kube- infra- default ci-maintenance nexus meilisearch monitoring registry-cache"
+                # Dry-run switch: set to "true" to log intended deletes only.
+                - name: DRY_RUN
+                  value: "false"
+              command:
+                - /bin/bash
+                - -ceu
+                - |
+                  now=$(date -u +%s)
+                  ttl_secs=$(( TTL_HOURS * 3600 ))
+                  deleted=0; scanned=0
+                  # name<TAB>creationTimestamp, one per line
+                  while IFS=$'\t' read -r name ts; do
+                    [ -n "$name" ] || continue
+                    scanned=$((scanned+1))
+                    # 1) must match an approved CI-test prefix
+                    matched=""
+                    for p in $SWEEP_PREFIXES; do
+                      case "$name" in "$p"*) matched=1;; esac
+                    done
+                    [ -n "$matched" ] || continue
+                    # 2) must NOT contain any protected substring
+                    protected=""
+                    for s in $PROTECT_SUBSTRINGS; do
+                      case "$name" in *"$s"*) protected=1;; esac
+                    done
+                    if [ -n "$protected" ]; then
+                      echo "SKIP (protected substring): $name"
+                      continue
+                    fi
+                    # 3) must be older than the TTL
+                    created=$(date -u -d "$ts" +%s 2>/dev/null || echo 0)
+                    [ "$created" -gt 0 ] || { echo "SKIP (unparseable ts): $name ($ts)"; continue; }
+                    age=$(( now - created ))
+                    if [ "$age" -lt "$ttl_secs" ]; then
+                      echo "keep  (age $((age/3600))h < ${TTL_HOURS}h): $name"
+                      continue
+                    fi
+                    if [ "$DRY_RUN" = "true" ]; then
+                      echo "WOULD DELETE (age $((age/3600))h): $name"
+                    else
+                      echo "DELETE (age $((age/3600))h): $name"
+                      kubectl delete namespace "$name" --wait=false || echo "  delete failed: $name"
+                      deleted=$((deleted+1))
+                    fi
+                  done < <(kubectl get namespaces \
+                    -o go-template='{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.creationTimestamp}}{{"\n"}}{{end}}')
+                  echo "sweep complete: scanned=$scanned deleted=$deleted (ttl=${TTL_HOURS}h dry_run=${DRY_RUN})"
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "128Mi"
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]


### PR DESCRIPTION
Closes artifact-keeper/artifact-keeper#2141

## Problem
The ephemeral per-run CI namespaces (`smoke-self-crash-*`, `smoke-self-pull-*`, `test-self-trivy-zero-*`, `test-self-clean-fixture-*`) are not reliably torn down — the in-job cleanup does not fire on the crash/cancel/self-crash paths, and the creators are split across the backend **and** web repos. Left alone they accumulate for weeks (10 namespaces / 48 pods / ~30-40Gi of OpenSearch JVM RSS observed on rocky), slowly exhausting node memory and compounding the CPU-load wedge risk.

## Fix
A **creator-agnostic** hourly `CronJob` (`ci-maintenance` namespace) that deletes any namespace which:
1. matches an approved CI-test prefix (`smoke-self-` / `test-self-`), **and**
2. does not contain any protected substring (prod/staging/artifact-keeper/mesh/argocd/kube-/… — belt-and-suspenders), **and**
3. is older than `TTL_HOURS` (default 4h — far above the longest e2e run).

Blast radius is constrained in the **script** (prefix allowlist + denylist + parseable-age guard), because namespace verbs cannot be RBAC name-scoped. `DRY_RUN` env switch included for validation. Synced by a selfHeal ArgoCD `Application` (tiny footprint — one CronJob, seconds/hour).

## Scope / notes
- Backstop only. A per-job `always()` cleanup in the creating workflows is complementary hardening tracked separately; this stands alone and catches the crash/cancel paths `always()` cannot.
- Bootstrap once on the runner cluster: `kubectl apply -f argocd/ci-namespace-sweeper-application.yaml`.
- Cross-repo `Closes` will not auto-close the backend issue; I will close #2141 after the sweeper is bootstrapped and a DRY_RUN pass on rocky confirms correct targeting.