### PR TITLE
Fix default helm deploy: DEPENDENCY_TRACK_API_KEY_FILE instead of sh wrapper (#199)

### DIFF
--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -140,15 +140,6 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.dependencyTrack.enabled }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              if [ -f /shared/dtrack-api-key ] && [ -s /shared/dtrack-api-key ]; then
-                export DEPENDENCY_TRACK_API_KEY="$(cat /shared/dtrack-api-key)"
-              fi
-              exec /usr/local/bin/artifact-keeper
-          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.backend.service.httpPort }}
@@ -162,6 +153,15 @@ spec:
               protocol: TCP
             {{- end }}
           env:
+            {{- if .Values.dependencyTrack.enabled }}
+            # The backend reads the Dependency-Track API key from this file
+            # (see resolve_api_key in dependency_track_service.rs). This replaces
+            # the previous `sh -c "export ...; exec"` command wrapper, which the
+            # shell-less distroless (ubi-micro) backend image cannot run
+            # (CreateContainerError: exec /bin/sh: no such file — iac#199).
+            - name: DEPENDENCY_TRACK_API_KEY_FILE
+              value: /shared/dtrack-api-key
+            {{- end }}
             {{- range $key, $value := .Values.backend.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}


### PR DESCRIPTION
Closes #199.

## Problem
With `dependencyTrack.enabled: true` (the chart DEFAULT), `backend-deployment.yaml` wrapped the main backend container in `command: ["/bin/sh","-c"]` to `cat /shared/dtrack-api-key` and `export DEPENDENCY_TRACK_API_KEY` before `exec`-ing the binary. The backend image is shell-less `ubi9/ubi-micro`, so the container fails with `CreateContainerError: exec "/bin/sh": no such file or directory` and never starts. This breaks the default `helm install` and is the cause of crash-looping backend pods.

## Fix
The backend already supports reading the key from a file — `resolve_api_key` in `dependency_track_service.rs` reads `DEPENDENCY_TRACK_API_KEY_FILE` (added when the image was hardened to distroless). So:
- Remove the `command`/`args` shell wrapper on the backend container (it now uses the image entrypoint `artifact-keeper` directly).
- Add `DEPENDENCY_TRACK_API_KEY_FILE: /shared/dtrack-api-key` to the backend env, guarded by `dependencyTrack.enabled`. The existing read-only `/shared` mount is unchanged.

No backend change, no migration, no RBAC. Verified: `helm template` with DTrack enabled renders the backend container with no `/bin/sh`, the file env present, and the `/shared` mount intact; the `dependencyTrack.enabled: false` path is unchanged (already had no override).