### PR TITLE
chore: bump chart to 1.4.0

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.3.1
-appVersion: "1.3.0"
+version: 1.4.0
+appVersion: "1.4.0"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary
Bump the Helm chart to 1.4.0 for the v1.4.0 release cut.

- `charts/artifact-keeper/Chart.yaml`: `appVersion` 1.3.0 -> 1.4.0 and chart `version` 1.3.1 -> 1.4.0 (the Chart Version Check gate requires a chart version bump when the chart changes).
- `charts/artifact-keeper/README.md`: regenerated with helm-docs (v1.14.2) — version badges only.

`helm lint` and `helm template` (all variants' base values) render cleanly. No dependency or image-tag versions changed.

Closes #209

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - documentation only (chart version bump)
