### PR TITLE
chore(release): bump chart to 1.5.0

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.4.2
-appVersion: "1.4.2"
+version: 1.5.0
+appVersion: "1.5.0"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
Closes #218

Bump chart version + appVersion to 1.5.0 for the v1.5.0 release. Part of the decoupled cut (api/SDK published, backend + iac cutting now; web follows).

