### PR TITLE
chore(release): bump chart to 1.5.3

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.5.2
-appVersion: "1.5.2"
+version: 1.5.3
+appVersion: "1.5.3"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
Chart version + appVersion 1.5.2 → 1.5.3 for the **v1.5.3 security hotfix** (cross-repo authz batch #2439/#2437). Chart-releaser tags artifact-keeper-1.5.3.