### PR TITLE
chore(release): chart 1.5.4 (backend SAML XSW security hotfix)

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.5.3
-appVersion: "1.5.3"
+version: 1.5.4
+appVersion: "1.5.4"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
+![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
Bumps the Helm chart to **1.5.4** (version + appVersion) to track the backend v1.5.4 security hotfix (SAML XSW authentication-bypass, artifact-keeper#2449). appVersion pins the backend and web images to `1.5.4`. README helm-docs badges regenerated (Version + AppVersion).

No template or values changes — version-only chart release.

Closes #223