### PR TITLE
chore: release chart 1.5.7

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.5.6
-appVersion: "1.5.6"
+version: 1.5.7
+appVersion: "1.5.7"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.6](https://img.shields.io/badge/AppVersion-1.5.6-informational?style=flat-square)
+![Version: 1.5.7](https://img.shields.io/badge/Version-1.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.7](https://img.shields.io/badge/AppVersion-1.5.7-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary
Version-align the Helm chart to **1.5.7** with the backend v1.5.7 security hotfix (artifact-keeper#2504).

- `Chart.yaml`: `version` and `appVersion` 1.5.6 -> 1.5.7
- `README.md`: helm-docs Version / AppVersion badges 1.5.6 -> 1.5.7

No template or functional changes.

Closes #228

## Test Checklist
- [x] N/A - version-only change (no template changes)

## Infrastructure
- [x] N/A - documentation/version only