### PR TITLE
chore: release chart 1.5.8

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.5.7
-appVersion: "1.5.7"
+version: 1.5.8
+appVersion: "1.5.8"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.5.7](https://img.shields.io/badge/Version-1.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.7](https://img.shields.io/badge/AppVersion-1.5.7-informational?style=flat-square)
+![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.8](https://img.shields.io/badge/AppVersion-1.5.8-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary
Version-align the Helm chart to **1.5.8** with the backend v1.5.8 bug-fix release (Docker migration artifact-keeper#2457 + outbound-proxy SSRF artifact-keeper#2570).

- `Chart.yaml`: `version` and `appVersion` 1.5.7 -> 1.5.8
- `README.md`: helm-docs Version / AppVersion badges 1.5.7 -> 1.5.8

No template or functional changes.

Closes #232

## Test Checklist
- [x] N/A - version-only change (no template changes)

## Infrastructure
- [x] N/A - documentation/version only
