### PR TITLE
chore(release): bump chart to 1.6.0

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.5.8
-appVersion: "1.5.8"
+version: 1.6.0
+appVersion: "1.6.0"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.8](https://img.shields.io/badge/AppVersion-1.5.8-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary
Release-prep version bump for the 1.6.0 cut. Aligns the Helm chart with the 1.6.0 release.

- `charts/artifact-keeper/Chart.yaml`: `version` and `appVersion` `1.5.8 -> 1.6.0` (both move in lockstep per every prior release commit).
- `charts/artifact-keeper/README.md`: regenerated with `helm-docs` v1.14.2; only the Version/AppVersion badges changed.

Image tags in `values.yaml` (backend/web/edge = `dev`, others pinned) are **not** touched: the default chart does not pin app image tags to appVersion per release, and pinned overlays (`values-production.yaml` @ 1.2.0, `values-registry-cache.yaml` @ 1.1.9) are separate, out-of-scope pins.

`helm lint charts/artifact-keeper` passes (0 charts failed).

Closes #235

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [x] N/A - documentation only
