### PR TITLE
chore(chart): exclude internal/CI values overlays from packaged chart

### DIFF
--- a/charts/artifact-keeper/.helmignore
+++ b/charts/artifact-keeper/.helmignore
@@ -27,3 +27,13 @@ README.md.gotmpl
 *.tmp
 *.bak
 *.orig
+
+# Internal build-infra and CI-only values overlays.
+# These are not customer configuration and must not ship inside the packaged
+# chart. They are still consumed by CI/internal tooling via `helm template -f`,
+# which .helmignore does not affect. Customer example overlays
+# (values-production.yaml, values-staging.yaml) are intentionally NOT ignored.
+values-registry-cache.yaml
+values-mesh-main.yaml
+values-mesh-peer.yaml
+values-smoke.yaml


### PR DESCRIPTION
## Summary
The packaged chart tgz was bundling internal build-infra and CI-only values overlays that should never reach a customer. This adds them to `charts/artifact-keeper/.helmignore`:

- `values-registry-cache.yaml` (internal dogfood pull-through-cache: internal DNS, pinned internal version, mirror env)
- `values-mesh-main.yaml`, `values-mesh-peer.yaml` (mesh-test CI overlays, point at `:dev` images)
- `values-smoke.yaml` (smoke / release-gate overlay)

Customer-facing example overlays (`values-production.yaml`, `values-staging.yaml`) intentionally keep shipping. `.helmignore` only affects `helm package`; CI/internal usage via `helm template -f` is unaffected.

Verified by packaging locally: the tgz now contains only `values.yaml`, `values-production.yaml`, `values-staging.yaml` (plus the conventional `ci/test-values.yaml`). The four internal overlays are excluded.

## Test Checklist
- [ ] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly (unchanged; packaging-only)
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - packaging metadata only, no template or rendered-output change

Rollback: revert this one-file change; no runtime impact. No chart version bump included (packaging-only, no rendered-output change); happy to bump if maintainers prefer.

Closes #239