### PR TITLE
feat(chart): opt-in fleet mode for many instances per cluster

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,8 +10,8 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.6.0
-appVersion: "1.6.0"
+version: 1.7.0
+appVersion: "1.7.0"
 home: https://artifactkeeper.com
 sources:
   - https://github.com/artifact-keeper/artifact-keeper

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 ## TL;DR
 
@@ -98,6 +98,31 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | edge.tolerations | list | `[]` | Per-component scheduling (overrides global) |
 | externalDatabase | object | `{"database":"artifact_registry","existingSecret":"","existingSecretKey":"DATABASE_URL","host":"","password":"","port":5432,"username":""}` | External database (used when postgres.enabled=false) |
 | externalSecrets | object | `{"enabled":false,"refreshInterval":"1h","secrets":{"dbCredentials":"artifact-keeper/${ENVIRONMENT}/db-credentials","dtAdminPassword":"artifact-keeper/${ENVIRONMENT}/dt-admin-password","jwtSecret":"artifact-keeper/${ENVIRONMENT}/jwt-secret","migrationEncryptionKey":"","opensearchAuth":"artifact-keeper/${ENVIRONMENT}/opensearch-auth","s3Keys":"artifact-keeper/${ENVIRONMENT}/s3-keys","smtpPassword":"artifact-keeper/${ENVIRONMENT}/smtp-password","webhookSecretKey":""},"storeKind":"ClusterSecretStore","storeName":"aws-secrets-manager"}` | External Secrets Operator When enabled, ExternalSecret CRDs replace the static Secret template. Requires External Secrets Operator installed on the cluster and a SecretStore or ClusterSecretStore configured for your provider. |
+| fleet | object | `{"enabled":false,"externalDatabaseBootstrap":{"adminSecret":"","enabled":true,"existingSecret":"","host":"","passwordKey":"password","port":5432},"guardrails":{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"resourceQuota":false,"scannerNamespace":"","searchNamespace":""},"hibernate":false,"host":"","instanceId":"","preset":"","storage":{"accessKeyIdKey":"S3_ACCESS_KEY_ID","existingSecret":"","secretAccessKeyKey":"S3_SECRET_ACCESS_KEY"}}` | Fleet mode: many instances per cluster sharing external services. Opt-in and off by default. When fleet.enabled is false none of the fleet templates render and backend/web sizing and replica counts come from the per-component values above, so a standard single-instance install is unaffected. When enabled, one release is one instance: sizing comes from a preset, the ingress serves a single host, and the instance uses a shared PostgreSQL server and shared object storage instead of in-release services. See templates/_helpers.tpl for the preset tables. |
+| fleet.enabled | bool | `false` | Enable fleet mode. Master switch for every fleet template and helper. |
+| fleet.externalDatabaseBootstrap | object | `{"adminSecret":"","enabled":true,"existingSecret":"","host":"","passwordKey":"password","port":5432}` | Bootstrap of the instance role and database on a shared PostgreSQL server. Runs as a pre-install/pre-upgrade hook Job that creates the role and database (named ak_<instanceId>) if they are absent. The backend runs its own schema migrations on startup, so the Job only guarantees the empty database and its owning role exist before the backend connects. |
+| fleet.externalDatabaseBootstrap.adminSecret | string | `""` | Name of an existing Secret holding superuser credentials for the shared server, used only by the bootstrap Job. Expected keys: username, password. |
+| fleet.externalDatabaseBootstrap.enabled | bool | `true` | Run the bootstrap Job. |
+| fleet.externalDatabaseBootstrap.existingSecret | string | `""` | Name of an existing Secret holding the instance role password. The same Secret is expected to hold the DATABASE_URL the backend consumes. |
+| fleet.externalDatabaseBootstrap.host | string | `""` | Host of the shared PostgreSQL read-write service. |
+| fleet.externalDatabaseBootstrap.passwordKey | string | `"password"` | Key in existingSecret holding the instance role password. |
+| fleet.externalDatabaseBootstrap.port | int | `5432` | Port of the shared PostgreSQL read-write service. |
+| fleet.guardrails | object | `{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"resourceQuota":false,"scannerNamespace":"","searchNamespace":""}` | Per-namespace guardrails. Each toggle is independent and off by default. ResourceQuota and LimitRange are sized from the preset; the NetworkPolicy restricts ingress to the named ingress-controller namespace and egress to the named shared-service namespaces plus DNS and outbound HTTPS. |
+| fleet.guardrails.databaseNamespace | string | `""` | Namespace of the shared PostgreSQL server (NetworkPolicy egress). |
+| fleet.guardrails.ingressNamespace | string | `"ingress-nginx"` | Namespace of the ingress controller allowed to reach the instance (NetworkPolicy ingress). |
+| fleet.guardrails.limitRange | bool | `false` | Emit a LimitRange sized from the preset. |
+| fleet.guardrails.networkPolicy | bool | `false` | Emit a NetworkPolicy scoping ingress and egress. |
+| fleet.guardrails.resourceQuota | bool | `false` | Emit a ResourceQuota sized from the preset. |
+| fleet.guardrails.scannerNamespace | string | `""` | Namespace of the shared scanner service (NetworkPolicy egress). |
+| fleet.guardrails.searchNamespace | string | `""` | Namespace of the shared search service (NetworkPolicy egress). |
+| fleet.hibernate | bool | `false` | Hibernate this instance by scaling backend and web to zero replicas. The release and its data stay in place; set back to false to resume. |
+| fleet.host | string | `""` | Public hostname for this instance, used as the single ingress host. When set, TLS for the host is expected to be terminated upstream (for example by a shared wildcard certificate on the ingress controller), so the chart does not emit a per-release ingress TLS block. |
+| fleet.instanceId | string | `""` | Stable identifier for this instance. Drives the derived database role and database name (ak_<instanceId>, with dashes normalized to underscores) and the object storage key prefix. |
+| fleet.preset | string | `""` | Sizing preset: small, medium, or large. Selects chart-owned backend and web replica counts and resource requests/limits (see _helpers.tpl). An empty value falls back to small; any other value fails the render. |
+| fleet.storage | object | `{"accessKeyIdKey":"S3_ACCESS_KEY_ID","existingSecret":"","secretAccessKeyKey":"S3_SECRET_ACCESS_KEY"}` | Object storage credentials for the shared S3-compatible backend. The non-secret settings (endpoint, bucket, region) are supplied through backend.env; the access keys are read from an existing Secret referenced here and injected into the backend as S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY. |
+| fleet.storage.accessKeyIdKey | string | `"S3_ACCESS_KEY_ID"` | Key in the Secret holding the access key id. |
+| fleet.storage.existingSecret | string | `""` | Name of an existing Secret holding the object storage access keys. |
+| fleet.storage.secretAccessKeyKey | string | `"S3_SECRET_ACCESS_KEY"` | Key in the Secret holding the secret access key. |
 | fullnameOverride | string | `""` |  |
 | gke.healthCheckPolicies.backend.requestPath | string | `"/livez"` | Health-check path for the backend BackendService. |
 | gke.healthCheckPolicies.dependencyTrack.requestPath | string | `"/api/version"` | Health-check path for the DependencyTrack BackendService. |

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -170,3 +170,180 @@ ServiceAccount name
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+=============================================================================
+Fleet mode helpers
+=============================================================================
+Fleet mode runs many instances per cluster, one Helm release per instance,
+sharing external database, search, scanning, and object storage. Every helper
+below is gated on fleet.enabled. When fleet mode is off (the default) each
+helper falls back to the existing per-component values, so rendered output is
+unchanged from a standard single-instance install.
+*/}}
+
+{{/*
+Returns the string "true" when this release runs in fleet mode.
+Callers gate on: eq (include "artifact-keeper.fleet.enabled" .) "true"
+*/}}
+{{- define "artifact-keeper.fleet.enabled" -}}
+{{- if and .Values.fleet .Values.fleet.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when a fleet instance is hibernated. Hibernated instances scale
+their backend and web workloads to zero replicas.
+*/}}
+{{- define "artifact-keeper.fleet.hibernate" -}}
+{{- if and (eq (include "artifact-keeper.fleet.enabled" .) "true") .Values.fleet.hibernate -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+PostgreSQL identifier for an instance (role and database share the name).
+Instance ids may use dashes; PostgreSQL identifiers use underscores, so the id
+is normalized and prefixed with ak_ to give a stable role/database name.
+*/}}
+{{- define "artifact-keeper.fleet.dbIdentifier" -}}
+{{- printf "ak_%s" (.Values.fleet.instanceId | replace "-" "_") -}}
+{{- end -}}
+
+{{/*
+Preset sizing table keyed on fleet.preset (small|medium|large). Returns YAML
+for the selected preset with backend/web replica counts and resource blocks.
+Presets are chart-owned so an instance spec only carries the preset name.
+An empty preset falls back to small; any other value fails the render.
+*/}}
+{{- define "artifact-keeper.fleet.presetSpec" -}}
+{{- $preset := default "small" .Values.fleet.preset -}}
+{{- $table := dict
+  "small" (dict
+    "backendReplicas" 1
+    "webReplicas" 1
+    "backend" (dict
+      "requests" (dict "cpu" "250m" "memory" "512Mi" "ephemeral-storage" "256Mi")
+      "limits" (dict "cpu" "1" "memory" "1Gi" "ephemeral-storage" "1Gi"))
+    "web" (dict
+      "requests" (dict "cpu" "100m" "memory" "128Mi" "ephemeral-storage" "128Mi")
+      "limits" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "1Gi")))
+  "medium" (dict
+    "backendReplicas" 2
+    "webReplicas" 2
+    "backend" (dict
+      "requests" (dict "cpu" "500m" "memory" "1Gi" "ephemeral-storage" "512Mi")
+      "limits" (dict "cpu" "2" "memory" "2Gi" "ephemeral-storage" "2Gi"))
+    "web" (dict
+      "requests" (dict "cpu" "250m" "memory" "256Mi" "ephemeral-storage" "256Mi")
+      "limits" (dict "cpu" "1" "memory" "1Gi" "ephemeral-storage" "2Gi")))
+  "large" (dict
+    "backendReplicas" 3
+    "webReplicas" 2
+    "backend" (dict
+      "requests" (dict "cpu" "1" "memory" "2Gi" "ephemeral-storage" "1Gi")
+      "limits" (dict "cpu" "4" "memory" "4Gi" "ephemeral-storage" "4Gi"))
+    "web" (dict
+      "requests" (dict "cpu" "500m" "memory" "512Mi" "ephemeral-storage" "512Mi")
+      "limits" (dict "cpu" "2" "memory" "2Gi" "ephemeral-storage" "2Gi")))
+  -}}
+{{- $spec := index $table $preset -}}
+{{- if not $spec -}}
+{{- fail (printf "fleet.preset=%q is not valid; use one of small, medium, large" $preset) -}}
+{{- end -}}
+{{- $spec | toYaml -}}
+{{- end -}}
+
+{{/*
+Backend replica count. Zero when hibernated, the preset count in fleet mode,
+otherwise the per-component value.
+*/}}
+{{- define "artifact-keeper.backend.replicaCount" -}}
+{{- if eq (include "artifact-keeper.fleet.hibernate" .) "true" -}}
+0
+{{- else if eq (include "artifact-keeper.fleet.enabled" .) "true" -}}
+{{- (fromYaml (include "artifact-keeper.fleet.presetSpec" .)).backendReplicas -}}
+{{- else -}}
+{{- .Values.backend.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Web replica count. Zero when hibernated, the preset count in fleet mode,
+otherwise the per-component value.
+*/}}
+{{- define "artifact-keeper.web.replicaCount" -}}
+{{- if eq (include "artifact-keeper.fleet.hibernate" .) "true" -}}
+0
+{{- else if eq (include "artifact-keeper.fleet.enabled" .) "true" -}}
+{{- (fromYaml (include "artifact-keeper.fleet.presetSpec" .)).webReplicas -}}
+{{- else -}}
+{{- .Values.web.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backend resources. Preset block in fleet mode, otherwise the per-component
+value (identical output to the previous direct toYaml of backend.resources).
+*/}}
+{{- define "artifact-keeper.backend.resources" -}}
+{{- if eq (include "artifact-keeper.fleet.enabled" .) "true" -}}
+{{- (fromYaml (include "artifact-keeper.fleet.presetSpec" .)).backend | toYaml -}}
+{{- else -}}
+{{- toYaml .Values.backend.resources -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Web resources. Preset block in fleet mode, otherwise the per-component value.
+*/}}
+{{- define "artifact-keeper.web.resources" -}}
+{{- if eq (include "artifact-keeper.fleet.enabled" .) "true" -}}
+{{- (fromYaml (include "artifact-keeper.fleet.presetSpec" .)).web | toYaml -}}
+{{- else -}}
+{{- toYaml .Values.web.resources -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Ingress host. Fleet instances derive it from fleet.host; otherwise ingress.host.
+*/}}
+{{- define "artifact-keeper.ingressHost" -}}
+{{- if and .Values.fleet .Values.fleet.host -}}
+{{- .Values.fleet.host -}}
+{{- else -}}
+{{- .Values.ingress.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Per-namespace guardrail sizing keyed on fleet.preset. Returns YAML with the
+ResourceQuota totals and the LimitRange container defaults/bounds for the
+selected preset. The quota totals sit above the summed backend+web
+requests/limits to leave headroom for init containers and the bootstrap Job.
+*/}}
+{{- define "artifact-keeper.fleet.guardrailSpec" -}}
+{{- $preset := default "small" .Values.fleet.preset -}}
+{{- $table := dict
+  "small" (dict
+    "quota" (dict "requestsCpu" "1" "requestsMemory" "1Gi" "limitsCpu" "4" "limitsMemory" "4Gi" "pods" "12" "pvcs" "4")
+    "limitRange" (dict
+      "defaultRequest" (dict "cpu" "100m" "memory" "128Mi")
+      "default" (dict "cpu" "500m" "memory" "512Mi")
+      "max" (dict "cpu" "2" "memory" "2Gi")))
+  "medium" (dict
+    "quota" (dict "requestsCpu" "2" "requestsMemory" "3Gi" "limitsCpu" "8" "limitsMemory" "8Gi" "pods" "20" "pvcs" "6")
+    "limitRange" (dict
+      "defaultRequest" (dict "cpu" "250m" "memory" "256Mi")
+      "default" (dict "cpu" "1" "memory" "1Gi")
+      "max" (dict "cpu" "3" "memory" "3Gi")))
+  "large" (dict
+    "quota" (dict "requestsCpu" "4" "requestsMemory" "6Gi" "limitsCpu" "16" "limitsMemory" "16Gi" "pods" "30" "pvcs" "8")
+    "limitRange" (dict
+      "defaultRequest" (dict "cpu" "500m" "memory" "512Mi")
+      "default" (dict "cpu" "2" "memory" "2Gi")
+      "max" (dict "cpu" "6" "memory" "6Gi")))
+  -}}
+{{- $spec := index $table $preset -}}
+{{- if not $spec -}}
+{{- fail (printf "fleet.preset=%q is not valid; use one of small, medium, large" $preset) -}}
+{{- end -}}
+{{- $spec | toYaml -}}
+{{- end -}}

--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/component: backend
 spec:
   {{- if not .Values.backend.autoscaling.enabled }}
-  replicas: {{ .Values.backend.replicaCount }}
+  replicas: {{ include "artifact-keeper.backend.replicaCount" . }}
   {{- end }}
   strategy:
     type: Recreate
@@ -249,8 +249,28 @@ spec:
             - name: METRICS_PORT
               value: {{ .Values.backend.metricsListener.port | quote }}
             {{- end }}
+            {{- if eq (include "artifact-keeper.fleet.enabled" .) "true" }}
+            # Object storage for this instance. Artifacts share one bucket with
+            # a per-instance key prefix; the non-secret settings (STORAGE_BACKEND,
+            # S3_BUCKET, S3_ENDPOINT, S3_REGION and any redirect flags) come from
+            # backend.env, and the prefix and access keys are injected here.
+            - name: S3_PREFIX
+              value: {{ .Values.fleet.instanceId | quote }}
+            {{- if .Values.fleet.storage.existingSecret }}
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fleet.storage.existingSecret }}
+                  key: {{ .Values.fleet.storage.accessKeyIdKey }}
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fleet.storage.existingSecret }}
+                  key: {{ .Values.fleet.storage.secretAccessKeyKey }}
+            {{- end }}
+            {{- end }}
           resources:
-            {{- toYaml .Values.backend.resources | nindent 12 }}
+            {{- include "artifact-keeper.backend.resources" . | nindent 12 }}
           startupProbe:
             httpGet:
               path: /readyz

--- a/charts/artifact-keeper/templates/fleet-db-bootstrap-job.yaml
+++ b/charts/artifact-keeper/templates/fleet-db-bootstrap-job.yaml
@@ -1,0 +1,138 @@
+{{/*
+=============================================================================
+Fleet mode: shared-database bootstrap Job
+=============================================================================
+Renders only in fleet mode (fleet.enabled) with the bootstrap enabled. Runs as
+a pre-install/pre-upgrade Helm hook: connects to the shared PostgreSQL server
+with the superuser credentials from fleet.externalDatabaseBootstrap.adminSecret
+and creates the instance role and database (named ak_<instanceId>) if they are
+absent. Schema migrations are NOT run here; the backend runs its own migrations
+on startup, so this Job only has to guarantee the role and empty database exist
+before the backend pod connects.
+
+The instance role password is read from fleet.externalDatabaseBootstrap.existingSecret
+so it matches the DATABASE_URL the backend consumes from the same Secret.
+=============================================================================
+*/}}
+{{- if and (eq (include "artifact-keeper.fleet.enabled" .) "true") .Values.fleet.externalDatabaseBootstrap.enabled }}
+{{- $ident := include "artifact-keeper.fleet.dbIdentifier" . }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-db-bootstrap
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-db-bootstrap
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "artifact-keeper.labels" . | nindent 8 }}
+        app.kubernetes.io/component: fleet-db-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      {{- with (.Values.backend.tolerations | default .Values.global.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.backend.nodeSelector | default .Values.global.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        fsGroup: 70
+      containers:
+        - name: db-bootstrap
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+              ephemeral-storage: 64Mi
+          env:
+            - name: HOME
+              value: /tmp
+            - name: PGHOST
+              value: {{ .Values.fleet.externalDatabaseBootstrap.host | quote }}
+            - name: PGPORT
+              value: {{ .Values.fleet.externalDatabaseBootstrap.port | quote }}
+            # Superuser connection to the shared server (bootstrap only).
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fleet.externalDatabaseBootstrap.adminSecret }}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fleet.externalDatabaseBootstrap.adminSecret }}
+                  key: password
+            # Instance role password, kept in sync with the instance DATABASE_URL.
+            - name: INSTANCE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.fleet.externalDatabaseBootstrap.existingSecret }}
+                  key: {{ .Values.fleet.externalDatabaseBootstrap.passwordKey }}
+            - name: INSTANCE_IDENT
+              value: {{ $ident | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              echo "[db-bootstrap] Waiting for shared PostgreSQL at ${PGHOST}:${PGPORT} ..."
+              for i in $(seq 1 60); do
+                if pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" >/dev/null 2>&1; then break; fi
+                if [ "$i" -eq 60 ]; then echo "[db-bootstrap] ERROR: database not reachable"; exit 1; fi
+                sleep 3
+              done
+
+              # Create or update the instance role (idempotent). The identifier is
+              # derived from the instance id (alphanumerics and underscores only),
+              # so it is safe to interpolate. The password is passed as a parameter.
+              psql -v ON_ERROR_STOP=1 -d postgres \
+                -v ident="$INSTANCE_IDENT" -v pw="$INSTANCE_DB_PASSWORD" <<'SQL'
+              SELECT format('CREATE ROLE %I LOGIN', :'ident')
+              WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'ident')
+              \gexec
+              SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'ident', :'pw')
+              \gexec
+              SQL
+
+              # Create the instance database owned by the role if it does not
+              # exist. CREATE DATABASE cannot run inside a transaction/DO block,
+              # so use the \gexec conditional-create pattern.
+              psql -v ON_ERROR_STOP=1 -d postgres \
+                -v ident="$INSTANCE_IDENT" <<'SQL'
+              SELECT format('CREATE DATABASE %I OWNER %I', :'ident', :'ident')
+              WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'ident')
+              \gexec
+              SQL
+
+              echo "[db-bootstrap] Role and database ${INSTANCE_IDENT} ready"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+{{- end }}

--- a/charts/artifact-keeper/templates/fleet-limitrange.yaml
+++ b/charts/artifact-keeper/templates/fleet-limitrange.yaml
@@ -1,0 +1,33 @@
+{{/*
+=============================================================================
+Fleet mode: per-namespace LimitRange
+=============================================================================
+Renders in fleet mode when fleet.guardrails.limitRange is enabled. Applies
+default container requests/limits (so unbounded pods cannot be scheduled) and a
+per-container ceiling, sized from fleet.preset. The ceiling sits above the
+preset backend limits so the instance workloads themselves are always
+admissible.
+=============================================================================
+*/}}
+{{- if and (eq (include "artifact-keeper.fleet.enabled" .) "true") .Values.fleet.guardrails.limitRange }}
+{{- $lr := (fromYaml (include "artifact-keeper.fleet.guardrailSpec" .)).limitRange }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-limits
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-guardrail
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: {{ $lr.defaultRequest.cpu | quote }}
+        memory: {{ $lr.defaultRequest.memory | quote }}
+      default:
+        cpu: {{ $lr.default.cpu | quote }}
+        memory: {{ $lr.default.memory | quote }}
+      max:
+        cpu: {{ $lr.max.cpu | quote }}
+        memory: {{ $lr.max.memory | quote }}
+{{- end }}

--- a/charts/artifact-keeper/templates/fleet-networkpolicy.yaml
+++ b/charts/artifact-keeper/templates/fleet-networkpolicy.yaml
@@ -1,0 +1,88 @@
+{{/*
+=============================================================================
+Fleet mode: per-namespace NetworkPolicy
+=============================================================================
+Renders in fleet mode when fleet.guardrails.networkPolicy is enabled, replacing
+the default in-namespace NetworkPolicy set (turn networkPolicy.enabled off for
+fleet instances). Ingress is allowed only from the named ingress-controller
+namespace and from pods within the instance namespace (web to backend). Egress
+is allowed only to the named shared-service namespaces (database, search,
+scanner), plus DNS and outbound HTTPS for object storage and external identity
+providers. Each shared-service egress rule renders only when its namespace is
+set. namespaceSelector uses the kubernetes.io/metadata.name label that
+Kubernetes stamps on every namespace automatically.
+=============================================================================
+*/}}
+{{- if and (eq (include "artifact-keeper.fleet.enabled" .) "true") .Values.fleet.guardrails.networkPolicy }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-fleet
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-guardrail
+spec:
+  # Applies to every pod in the instance namespace.
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Ingress controller reaching backend and web.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.fleet.guardrails.ingressNamespace | quote }}
+      ports:
+        - port: {{ .Values.backend.service.httpPort }}
+          protocol: TCP
+        - port: {{ .Values.web.service.port }}
+          protocol: TCP
+    # Intra-namespace traffic (web to backend, backend gRPC).
+    - from:
+        - podSelector: {}
+  egress:
+    # DNS resolution.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Intra-namespace traffic.
+    - to:
+        - podSelector: {}
+    {{- if .Values.fleet.guardrails.databaseNamespace }}
+    # Shared PostgreSQL server.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.fleet.guardrails.databaseNamespace | quote }}
+      ports:
+        - port: {{ .Values.fleet.externalDatabaseBootstrap.port }}
+          protocol: TCP
+    {{- end }}
+    {{- if .Values.fleet.guardrails.searchNamespace }}
+    # Shared search service.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.fleet.guardrails.searchNamespace | quote }}
+      ports:
+        - port: 9200
+          protocol: TCP
+    {{- end }}
+    {{- if .Values.fleet.guardrails.scannerNamespace }}
+    # Shared scanner service.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.fleet.guardrails.scannerNamespace | quote }}
+      ports:
+        - port: 8090
+          protocol: TCP
+    {{- end }}
+    # Outbound HTTPS for object storage and any external identity or registry.
+    - ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/charts/artifact-keeper/templates/fleet-resourcequota.yaml
+++ b/charts/artifact-keeper/templates/fleet-resourcequota.yaml
@@ -1,0 +1,27 @@
+{{/*
+=============================================================================
+Fleet mode: per-namespace ResourceQuota
+=============================================================================
+Renders in fleet mode when fleet.guardrails.resourceQuota is enabled. Caps
+total requests, limits, pod count, and PVC count for the instance namespace,
+sized from fleet.preset.
+=============================================================================
+*/}}
+{{- if and (eq (include "artifact-keeper.fleet.enabled" .) "true") .Values.fleet.guardrails.resourceQuota }}
+{{- $g := (fromYaml (include "artifact-keeper.fleet.guardrailSpec" .)).quota }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "artifact-keeper.fullname" . }}-quota
+  labels:
+    {{- include "artifact-keeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fleet-guardrail
+spec:
+  hard:
+    requests.cpu: {{ $g.requestsCpu | quote }}
+    requests.memory: {{ $g.requestsMemory | quote }}
+    limits.cpu: {{ $g.limitsCpu | quote }}
+    limits.memory: {{ $g.limitsMemory | quote }}
+    pods: {{ $g.pods | quote }}
+    persistentvolumeclaims: {{ $g.pvcs | quote }}
+{{- end }}

--- a/charts/artifact-keeper/templates/ingress.yaml
+++ b/charts/artifact-keeper/templates/ingress.yaml
@@ -23,14 +23,14 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
+  {{- if and .Values.ingress.tls.enabled (ne (include "artifact-keeper.fleet.enabled" .) "true") }}
   tls:
     - hosts:
-        - {{ .Values.ingress.host }}
+        - {{ include "artifact-keeper.ingressHost" . }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    - host: {{ include "artifact-keeper.ingressHost" . }}
       http:
         paths:
           # API and health endpoints

--- a/charts/artifact-keeper/templates/web-deployment.yaml
+++ b/charts/artifact-keeper/templates/web-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "artifact-keeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
 spec:
-  replicas: {{ .Values.web.replicaCount }}
+  replicas: {{ include "artifact-keeper.web.replicaCount" . }}
   selector:
     matchLabels:
       {{- include "artifact-keeper.web.selectorLabels" . | nindent 6 }}
@@ -66,7 +66,7 @@ spec:
             - name: NODE_ENV
               value: {{ .Values.web.env.NODE_ENV | quote }}
           resources:
-            {{- toYaml .Values.web.resources | nindent 12 }}
+            {{- include "artifact-keeper.web.resources" . | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -888,3 +888,82 @@ gke:
     dependencyTrack:
       # -- Health-check path for the DependencyTrack BackendService.
       requestPath: /api/version
+
+# -- Fleet mode: many instances per cluster sharing external services.
+# Opt-in and off by default. When fleet.enabled is false none of the fleet
+# templates render and backend/web sizing and replica counts come from the
+# per-component values above, so a standard single-instance install is
+# unaffected. When enabled, one release is one instance: sizing comes from a
+# preset, the ingress serves a single host, and the instance uses a shared
+# PostgreSQL server and shared object storage instead of in-release services.
+# See templates/_helpers.tpl for the preset tables.
+fleet:
+  # -- Enable fleet mode. Master switch for every fleet template and helper.
+  enabled: false
+  # -- Stable identifier for this instance. Drives the derived database role and
+  # database name (ak_<instanceId>, with dashes normalized to underscores) and
+  # the object storage key prefix.
+  instanceId: ""
+  # -- Public hostname for this instance, used as the single ingress host. When
+  # set, TLS for the host is expected to be terminated upstream (for example by
+  # a shared wildcard certificate on the ingress controller), so the chart does
+  # not emit a per-release ingress TLS block.
+  host: ""
+  # -- Sizing preset: small, medium, or large. Selects chart-owned backend and
+  # web replica counts and resource requests/limits (see _helpers.tpl). An empty
+  # value falls back to small; any other value fails the render.
+  preset: ""
+  # -- Hibernate this instance by scaling backend and web to zero replicas. The
+  # release and its data stay in place; set back to false to resume.
+  hibernate: false
+  # -- Object storage credentials for the shared S3-compatible backend. The
+  # non-secret settings (endpoint, bucket, region) are supplied through
+  # backend.env; the access keys are read from an existing Secret referenced
+  # here and injected into the backend as S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY.
+  storage:
+    # -- Name of an existing Secret holding the object storage access keys.
+    existingSecret: ""
+    # -- Key in the Secret holding the access key id.
+    accessKeyIdKey: S3_ACCESS_KEY_ID
+    # -- Key in the Secret holding the secret access key.
+    secretAccessKeyKey: S3_SECRET_ACCESS_KEY
+  # -- Bootstrap of the instance role and database on a shared PostgreSQL server.
+  # Runs as a pre-install/pre-upgrade hook Job that creates the role and database
+  # (named ak_<instanceId>) if they are absent. The backend runs its own schema
+  # migrations on startup, so the Job only guarantees the empty database and its
+  # owning role exist before the backend connects.
+  externalDatabaseBootstrap:
+    # -- Run the bootstrap Job.
+    enabled: true
+    # -- Host of the shared PostgreSQL read-write service.
+    host: ""
+    # -- Port of the shared PostgreSQL read-write service.
+    port: 5432
+    # -- Name of an existing Secret holding the instance role password. The same
+    # Secret is expected to hold the DATABASE_URL the backend consumes.
+    existingSecret: ""
+    # -- Key in existingSecret holding the instance role password.
+    passwordKey: password
+    # -- Name of an existing Secret holding superuser credentials for the shared
+    # server, used only by the bootstrap Job. Expected keys: username, password.
+    adminSecret: ""
+  # -- Per-namespace guardrails. Each toggle is independent and off by default.
+  # ResourceQuota and LimitRange are sized from the preset; the NetworkPolicy
+  # restricts ingress to the named ingress-controller namespace and egress to
+  # the named shared-service namespaces plus DNS and outbound HTTPS.
+  guardrails:
+    # -- Emit a ResourceQuota sized from the preset.
+    resourceQuota: false
+    # -- Emit a LimitRange sized from the preset.
+    limitRange: false
+    # -- Emit a NetworkPolicy scoping ingress and egress.
+    networkPolicy: false
+    # -- Namespace of the ingress controller allowed to reach the instance
+    # (NetworkPolicy ingress).
+    ingressNamespace: ingress-nginx
+    # -- Namespace of the shared PostgreSQL server (NetworkPolicy egress).
+    databaseNamespace: ""
+    # -- Namespace of the shared search service (NetworkPolicy egress).
+    searchNamespace: ""
+    # -- Namespace of the shared scanner service (NetworkPolicy egress).
+    scannerNamespace: ""


### PR DESCRIPTION
## Summary

Adds an opt-in `fleet` section to the `artifact-keeper` chart so many instances can run in one cluster against shared external services (PostgreSQL, object storage, search, scanning). This implements #247.

Fleet mode is off by default. When `fleet.enabled` is false, none of the fleet templates render and backend/web replica counts and resources come from the existing per-component values, so a standard single-instance install is byte-for-byte unchanged (verified below).

When `fleet.enabled` is true, one Helm release is one instance:

- **Sizing** comes from `fleet.preset` (`small`, `medium`, `large`). Replica counts and resource requests/limits live in chart-owned tables in `_helpers.tpl`, so an instance spec only carries the preset name. An empty preset falls back to `small`; any other value fails the render with a clear message.
- **Hibernate**: `fleet.hibernate: true` scales backend and web to zero replicas while leaving the release and its data in place.
- **Ingress**: a single host from `fleet.host`, with no per-release TLS block (TLS is expected to be terminated upstream, for example by a shared wildcard certificate on the ingress controller).
- **Object storage**: the backend reads S3 credentials from an existing Secret (`fleet.storage.existingSecret`, keys `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY`) and uses a per-instance key prefix. Non-secret settings stay in `backend.env`.
- **Database bootstrap**: a pre-install/pre-upgrade hook Job creates the instance role and database (`ak_<instanceId>`) on a shared PostgreSQL server if absent. The backend runs its own schema migrations on startup, so the Job only guarantees the empty database and role exist.
- **Guardrails**: optional per-namespace `ResourceQuota`, `LimitRange`, and `NetworkPolicy`, each gated on an independent toggle under `fleet.guardrails`. The NetworkPolicy's ingress-controller namespace and shared-service namespaces are values, not hardcoded.

Chart version bumped `1.6.0` -> `1.7.0` (no `artifact-keeper-1.7.0` release tag exists yet) and the README regenerated with helm-docs.

Files changed:
- `Chart.yaml` version and appVersion bump
- `README.md` regenerated by helm-docs
- `values.yaml` new `fleet:` section, all defaults off
- `templates/_helpers.tpl` preset and guardrail tables, replica/resource/host helpers
- `templates/backend-deployment.yaml`, `templates/web-deployment.yaml` replicas/resources via helpers, S3 env wiring
- `templates/ingress.yaml` host override, TLS block suppressed in fleet mode
- `templates/fleet-db-bootstrap-job.yaml`, `templates/fleet-resourcequota.yaml`, `templates/fleet-limitrange.yaml`, `templates/fleet-networkpolicy.yaml` new

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

Rollback: fleet mode is opt-in and default-off. Reverting the release to the prior chart version, or leaving `fleet.enabled: false`, restores the previous behavior with no change to rendered output.

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [ ] N/A - documentation only

### Verification performed

- `helm lint` passes for the default profile and for a fleet-enabled profile.
- `helm template` fleet-enabled renders the expected set: the bootstrap Job, ResourceQuota, LimitRange, and NetworkPolicy, with backend/web sized from the preset, the ingress host overridden, and the S3 credential env wired.
- Default render (`fleet.enabled: false`) diffs against the base chart with only the version labels (`helm.sh/chart`, `app.kubernetes.io/version`) changed; no structural differences.
- Hibernate renders backend and web at 0 replicas.
- An invalid preset fails the render with: `fleet.preset="xlarge" is not valid; use one of small, medium, large`.
