### PR TITLE
fix(chart): wire S3 credentials to the env vars the backend reads

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,7 +10,7 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: "1.7.1"
 home: https://artifactkeeper.com
 sources:

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 ## TL;DR
 

--- a/charts/artifact-keeper/templates/backend-deployment.yaml
+++ b/charts/artifact-keeper/templates/backend-deployment.yaml
@@ -269,6 +269,33 @@ spec:
                   key: {{ .Values.fleet.storage.secretAccessKeyKey }}
             {{- end }}
             {{- end }}
+            {{- /*
+            S3 credentials for a standard (non-fleet) install. The backend reads
+            S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY; these come from the
+            chart-managed Secret (secrets.s3AccessKey / secrets.s3SecretKey) or
+            the ExternalSecret. Skipped when the fleet object-storage Secret
+            supplies them (that path takes precedence, injected above) and when
+            secrets.existingSecret is in use, since a user-managed Secret may
+            store the keys under different names.
+            */}}
+            {{- $fleetManagedS3 := false }}
+            {{- if eq (include "artifact-keeper.fleet.enabled" .) "true" }}
+            {{- $fleetManagedS3 = .Values.fleet.storage.existingSecret }}
+            {{- end }}
+            {{- if and (not $fleetManagedS3) (eq (lower (.Values.backend.env.STORAGE_BACKEND | default "")) "s3") }}
+            {{- if or .Values.externalSecrets.enabled (and (not .Values.secrets.existingSecret) .Values.secrets.s3AccessKey) }}
+            - name: S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "artifact-keeper.secretName" . }}
+                  key: S3_ACCESS_KEY_ID
+            - name: S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "artifact-keeper.secretName" . }}
+                  key: S3_SECRET_ACCESS_KEY
+            {{- end }}
+            {{- end }}
           resources:
             {{- include "artifact-keeper.backend.resources" . | nindent 12 }}
           startupProbe:

--- a/charts/artifact-keeper/templates/external-secrets.yaml
+++ b/charts/artifact-keeper/templates/external-secrets.yaml
@@ -46,12 +46,13 @@ spec:
       remoteRef:
         key: {{ .Values.externalSecrets.secrets.dbCredentials }}
         property: password
-    # S3 storage credentials
-    - secretKey: S3_ACCESS_KEY
+    # S3 storage credentials. The secret keys match the environment variables
+    # the backend reads (S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY).
+    - secretKey: S3_ACCESS_KEY_ID
       remoteRef:
         key: {{ .Values.externalSecrets.secrets.s3Keys }}
         property: access-key
-    - secretKey: S3_SECRET_KEY
+    - secretKey: S3_SECRET_ACCESS_KEY
       remoteRef:
         key: {{ .Values.externalSecrets.secrets.s3Keys }}
         property: secret-key

--- a/charts/artifact-keeper/templates/secrets.yaml
+++ b/charts/artifact-keeper/templates/secrets.yaml
@@ -25,8 +25,12 @@ stringData:
   POSTGRES_PASSWORD: {{ .Values.externalDatabase.password | quote }}
   DATABASE_URL: {{ include "artifact-keeper.databaseUrl" . | quote }}
   {{- end }}
-  S3_ACCESS_KEY: {{ .Values.secrets.s3AccessKey | quote }}
-  S3_SECRET_KEY: {{ .Values.secrets.s3SecretKey | quote }}
+  {{- if .Values.secrets.s3AccessKey }}
+  S3_ACCESS_KEY_ID: {{ .Values.secrets.s3AccessKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.s3SecretKey }}
+  S3_SECRET_ACCESS_KEY: {{ .Values.secrets.s3SecretKey | quote }}
+  {{- end }}
   {{- if and .Values.opensearch.enabled (not .Values.opensearch.disableSecurityPlugin) }}
   OPENSEARCH_USERNAME: {{ .Values.opensearch.auth.username | quote }}
   OPENSEARCH_PASSWORD: {{ .Values.opensearch.auth.password | quote }}

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -820,6 +820,10 @@ secrets:
   # and secret-manager workflows where the Secret is provisioned out of band.
   existingSecret: ""
   jwtSecret: ""
+  # S3-compatible object storage credentials. Injected into the backend as
+  # S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY when backend.env.STORAGE_BACKEND is
+  # "s3" and the fleet object-storage Secret is not in use. Leave empty for
+  # filesystem storage or when using IAM roles (IRSA) for credentials.
   s3AccessKey: ""
   s3SecretKey: ""
   # SMTP password (only used when backend.env.SMTP_HOST is set)


### PR DESCRIPTION
## Summary

Fixes S3 credentials configured through chart values being silently ignored by the backend (Closes #206).

Two problems combined to break S3 auth for a standard install:

1. The chart-managed Secret (`templates/secrets.yaml`) and the ExternalSecret (`templates/external-secrets.yaml`) stored `secrets.s3AccessKey` / `secrets.s3SecretKey` under the keys `S3_ACCESS_KEY` and `S3_SECRET_KEY`. The backend reads `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY`, so those keys were never consumed.
2. The backend Deployment only referenced S3 credential keys inside the fleet object-storage path (`fleet.storage.existingSecret`). For a standard install there was no env wiring at all, so even a correctly named Secret would not have reached the container.

The result was the runtime error reported in the issue: `S3 storage configured with custom endpoint but no credentials found. Set S3_ACCESS_KEY_ID + S3_SECRET_ACCESS_KEY ...`.

### Changes

- Store the credentials under `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` in both the chart-managed Secret and the ExternalSecret, and render them only when the corresponding value is set (matching how the other optional secrets in the file are gated).
- Inject `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` into the backend container from the chart Secret when `backend.env.STORAGE_BACKEND` is `s3`.
- The fleet object-storage Secret keeps precedence: when `fleet.storage.existingSecret` is set, the existing fleet path supplies the keys and the new block is skipped, so the env vars are never defined twice.
- `secrets.existingSecret` is intentionally left untouched: when a user supplies their own Secret the chart does not assume it uses these key names, so no env is auto-injected for that case.
- Added a values.yaml comment documenting the credential mapping, bumped the chart version to 1.7.2, regenerated the README with helm-docs.

### Backward compatibility

Users who provisioned their own Secret via `secrets.existingSecret` or an out-of-band ExternalSecret may currently store S3 credentials under the old key names (`S3_ACCESS_KEY` / `S3_SECRET_KEY`). This PR does not migrate those. For `secrets.existingSecret` the chart no longer injects S3 env automatically (it never did before), so such users should ensure their Secret exposes `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` and reference them through `backend.env` or their own means. Installs that rely on IAM roles (IRSA) for credentials are unaffected: with `secrets.s3AccessKey` empty, no static-credential env vars are injected.

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [ ] N/A - documentation only

### Verification performed

- `helm lint .` passes.
- `--set backend.env.STORAGE_BACKEND=s3 --set secrets.s3AccessKey=... --set secrets.s3SecretKey=...`: Secret stores the keys under `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` and the backend Deployment injects both from the chart Secret.
- `--set externalSecrets.enabled=true --set backend.env.STORAGE_BACKEND=s3`: the ExternalSecret maps to `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` and the Deployment injects them.
- `--set fleet.enabled=true --set fleet.storage.existingSecret=...`: fleet path unchanged, credentials come from the fleet Secret, and each env var is defined exactly once (no double definition).
- `--set secrets.existingSecret=...`: no S3 env auto-injected.
- Default render (no S3 values) diffs against `origin/main` only by the chart-version labels plus removal of the two always-empty, never-read placeholder keys (`S3_ACCESS_KEY: ""` / `S3_SECRET_KEY: ""`) from the Secret.

### Rollback

Revert the commit or roll back to chart 1.7.1. No data or state migration is involved; the change only affects how env vars are rendered.