### PR TITLE
docs(chart): document optional components and OpenSearch Postgres fallback

### DIFF
--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -252,6 +252,21 @@ The chart deploys the following components:
 | **Scanner-adapter** | In-house Harbor scanner-adapter for container-image Trivy scans (`TRIVY_ADAPTER_URL`); stateless, multi-arch, no PVC | Enabled |
 | **DependencyTrack** | SBOM analysis platform for license and vulnerability correlation | Enabled |
 
+### Optional components
+
+OpenSearch, Trivy, the scanner-adapter, and DependencyTrack are optional. Each is
+controlled by its own `enabled` flag (`opensearch.enabled`, `trivy.enabled`,
+`scannerAdapter.enabled`, `dependencyTrack.enabled`). Turning one off removes both
+its workload and the matching backend environment wiring, so the backend runs
+without it and without pointing at a service that is not there.
+
+OpenSearch in particular is a search accelerator, not a hard dependency. With
+`opensearch.enabled: false` the backend serves artifact search from PostgreSQL
+full-text search instead, so search keeps working (at lower scale) with no extra
+memory footprint. Plan for roughly 1Gi to 2Gi of memory for a single-node
+OpenSearch pod (JVM heap plus off-heap and page cache) when you do enable it; see
+`opensearch.javaOpts` and the OpenSearch OOMKill note under Troubleshooting.
+
 ### Component Diagram
 
 ```

--- a/charts/artifact-keeper/README.md.gotmpl
+++ b/charts/artifact-keeper/README.md.gotmpl
@@ -159,6 +159,21 @@ The chart deploys the following components:
 | **Scanner-adapter** | In-house Harbor scanner-adapter for container-image Trivy scans (`TRIVY_ADAPTER_URL`); stateless, multi-arch, no PVC | Enabled |
 | **DependencyTrack** | SBOM analysis platform for license and vulnerability correlation | Enabled |
 
+### Optional components
+
+OpenSearch, Trivy, the scanner-adapter, and DependencyTrack are optional. Each is
+controlled by its own `enabled` flag (`opensearch.enabled`, `trivy.enabled`,
+`scannerAdapter.enabled`, `dependencyTrack.enabled`). Turning one off removes both
+its workload and the matching backend environment wiring, so the backend runs
+without it and without pointing at a service that is not there.
+
+OpenSearch in particular is a search accelerator, not a hard dependency. With
+`opensearch.enabled: false` the backend serves artifact search from PostgreSQL
+full-text search instead, so search keeps working (at lower scale) with no extra
+memory footprint. Plan for roughly 1Gi to 2Gi of memory for a single-node
+OpenSearch pod (JVM heap plus off-heap and page cache) when you do enable it; see
+`opensearch.javaOpts` and the OpenSearch OOMKill note under Troubleshooting.
+
 ### Component Diagram
 
 ```


### PR DESCRIPTION
## Summary

The Helm chart already ships `opensearch`, `trivy`, `scannerAdapter`, and `dependencyTrack` as optional components, each gated by its own `enabled` flag, with the backend deployment injecting the matching env (`OPENSEARCH_URL`, `TRIVY_URL`, `TRIVY_ADAPTER_URL`, `SCAN_WORKSPACE_PATH`) only when the component is enabled. The README's Components table lists all four, but it never explained what happens when one is turned off, in particular that OpenSearch is a search accelerator rather than a hard dependency.

This is a docs-only change. It adds an 'Optional components' note to the chart README covering:
- each component is optional via its `enabled` flag (all four flag names listed)
- disabling a component removes both its workload and the backend wiring that points at it
- with `opensearch.enabled: false` the backend falls back to PostgreSQL full-text search
- rough memory guidance (1Gi to 2Gi) for a single-node OpenSearch pod

Both `README.md` and its `README.md.gotmpl` source are updated; `README.md` was regenerated with helm-docs so they stay in sync.

Closes #260

## Test Checklist
- [ ] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [ ] Rollback strategy documented

## Infrastructure
- [ ] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - documentation only

Note: SonarCloud is a known-broken check on this repo (fails all PRs in about 7 seconds, tracked in #251). A SonarCloud failure here is not caused by this change.