### PR TITLE
fix(chart): size fleet ResourceQuota for enabled optional components

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,7 +10,7 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.7.5
+version: 1.8.0
 appVersion: "1.6.0"
 home: https://artifactkeeper.com
 sources:

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.7.5](https://img.shields.io/badge/Version-1.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 ## TL;DR
 
@@ -99,7 +99,7 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | edge.tolerations | list | `[]` | Per-component scheduling (overrides global) |
 | externalDatabase | object | `{"database":"artifact_registry","existingSecret":"","existingSecretKey":"DATABASE_URL","host":"","password":"","port":5432,"username":""}` | External database (used when postgres.enabled=false) |
 | externalSecrets | object | `{"enabled":false,"refreshInterval":"1h","secrets":{"dbCredentials":"artifact-keeper/${ENVIRONMENT}/db-credentials","dtAdminPassword":"artifact-keeper/${ENVIRONMENT}/dt-admin-password","jwtSecret":"artifact-keeper/${ENVIRONMENT}/jwt-secret","migrationEncryptionKey":"","opensearchAuth":"artifact-keeper/${ENVIRONMENT}/opensearch-auth","s3Keys":"artifact-keeper/${ENVIRONMENT}/s3-keys","smtpPassword":"artifact-keeper/${ENVIRONMENT}/smtp-password","webhookSecretKey":""},"storeKind":"ClusterSecretStore","storeName":"aws-secrets-manager"}` | External Secrets Operator When enabled, ExternalSecret CRDs replace the static Secret template. Requires External Secrets Operator installed on the cluster and a SecretStore or ClusterSecretStore configured for your provider. |
-| fleet | object | `{"enabled":false,"externalDatabaseBootstrap":{"adminSecret":"","enabled":true,"existingSecret":"","host":"","passwordKey":"password","port":5432},"guardrails":{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"resourceQuota":false,"scannerNamespace":"","searchNamespace":""},"hibernate":false,"host":"","instanceId":"","preset":"","storage":{"accessKeyIdKey":"S3_ACCESS_KEY_ID","existingSecret":"","secretAccessKeyKey":"S3_SECRET_ACCESS_KEY"}}` | Fleet mode: many instances per cluster sharing external services. Opt-in and off by default. When fleet.enabled is false none of the fleet templates render and backend/web sizing and replica counts come from the per-component values above, so a standard single-instance install is unaffected. When enabled, one release is one instance: sizing comes from a preset, the ingress serves a single host, and the instance uses a shared PostgreSQL server and shared object storage instead of in-release services. See templates/_helpers.tpl for the preset tables. |
+| fleet | object | `{"enabled":false,"externalDatabaseBootstrap":{"adminSecret":"","enabled":true,"existingSecret":"","host":"","passwordKey":"password","port":5432},"guardrails":{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"quotaOverrides":{},"resourceQuota":false,"scannerNamespace":"","searchNamespace":""},"hibernate":false,"host":"","instanceId":"","preset":"","storage":{"accessKeyIdKey":"S3_ACCESS_KEY_ID","existingSecret":"","secretAccessKeyKey":"S3_SECRET_ACCESS_KEY"}}` | Fleet mode: many instances per cluster sharing external services. Opt-in and off by default. When fleet.enabled is false none of the fleet templates render and backend/web sizing and replica counts come from the per-component values above, so a standard single-instance install is unaffected. When enabled, one release is one instance: sizing comes from a preset, the ingress serves a single host, and the instance uses a shared PostgreSQL server and shared object storage instead of in-release services. See templates/_helpers.tpl for the preset tables. |
 | fleet.enabled | bool | `false` | Enable fleet mode. Master switch for every fleet template and helper. |
 | fleet.externalDatabaseBootstrap | object | `{"adminSecret":"","enabled":true,"existingSecret":"","host":"","passwordKey":"password","port":5432}` | Bootstrap of the instance role and database on a shared PostgreSQL server. Runs as a pre-install/pre-upgrade hook Job that creates the role and database (named ak_<instanceId>) if they are absent. The backend runs its own schema migrations on startup, so the Job only guarantees the empty database and its owning role exist before the backend connects. |
 | fleet.externalDatabaseBootstrap.adminSecret | string | `""` | Name of an existing Secret holding superuser credentials for the shared server, used only by the bootstrap Job. Expected keys: username, password. |
@@ -108,11 +108,12 @@ kubectl delete pvc -l app.kubernetes.io/instance=ak -n artifact-keeper
 | fleet.externalDatabaseBootstrap.host | string | `""` | Host of the shared PostgreSQL read-write service. |
 | fleet.externalDatabaseBootstrap.passwordKey | string | `"password"` | Key in existingSecret holding the instance role password. |
 | fleet.externalDatabaseBootstrap.port | int | `5432` | Port of the shared PostgreSQL read-write service. |
-| fleet.guardrails | object | `{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"resourceQuota":false,"scannerNamespace":"","searchNamespace":""}` | Per-namespace guardrails. Each toggle is independent and off by default. ResourceQuota and LimitRange are sized from the preset; the NetworkPolicy restricts ingress to the named ingress-controller namespace and egress to the named shared-service namespaces plus DNS and outbound HTTPS. |
+| fleet.guardrails | object | `{"databaseNamespace":"","ingressNamespace":"ingress-nginx","limitRange":false,"networkPolicy":false,"quotaOverrides":{},"resourceQuota":false,"scannerNamespace":"","searchNamespace":""}` | Per-namespace guardrails. Each toggle is independent and off by default. ResourceQuota and LimitRange are sized from the preset; the NetworkPolicy restricts ingress to the named ingress-controller namespace and egress to the named shared-service namespaces plus DNS and outbound HTTPS. |
 | fleet.guardrails.databaseNamespace | string | `""` | Namespace of the shared PostgreSQL server (NetworkPolicy egress). |
 | fleet.guardrails.ingressNamespace | string | `"ingress-nginx"` | Namespace of the ingress controller allowed to reach the instance (NetworkPolicy ingress). |
 | fleet.guardrails.limitRange | bool | `false` | Emit a LimitRange sized from the preset. |
 | fleet.guardrails.networkPolicy | bool | `false` | Emit a NetworkPolicy scoping ingress and egress. |
+| fleet.guardrails.quotaOverrides | object | `{}` | Explicit ResourceQuota overrides. By default the quota is sized from the preset and grows to account for each enabled optional component (trivy, scannerAdapter, opensearch, dependencyTrack). Set any of these keys to replace the corresponding computed total outright; unset keys stay component-aware. Values are used verbatim as Kubernetes quantities, for example limitsMemory: 32Gi or pods: 40. Keys: requestsCpu, requestsMemory, limitsCpu, limitsMemory, pods, pvcs. |
 | fleet.guardrails.resourceQuota | bool | `false` | Emit a ResourceQuota sized from the preset. |
 | fleet.guardrails.scannerNamespace | string | `""` | Namespace of the shared scanner service (NetworkPolicy egress). |
 | fleet.guardrails.searchNamespace | string | `""` | Namespace of the shared search service (NetworkPolicy egress). |
@@ -266,6 +267,17 @@ full-text search instead, so search keeps working (at lower scale) with no extra
 memory footprint. Plan for roughly 1Gi to 2Gi of memory for a single-node
 OpenSearch pod (JVM heap plus off-heap and page cache) when you do enable it; see
 `opensearch.javaOpts` and the OpenSearch OOMKill note under Troubleshooting.
+
+In fleet mode the per-namespace `ResourceQuota` (see `fleet.guardrails.resourceQuota`)
+is sized from the preset and then grows to account for whichever optional
+components are enabled, so their pods and PVCs actually fit within the quota. If
+the preset only covered backend and web, enabling trivy, the scanner-adapter,
+OpenSearch, or DependencyTrack would push the namespace over its pod and memory
+limits and leave those workloads (and the database bootstrap Job) unschedulable.
+To pin any total by hand, set the matching key under
+`fleet.guardrails.quotaOverrides` (for example `limitsMemory: 32Gi`); an override
+replaces the computed value outright while the remaining totals stay
+component-aware.
 
 ### Component Diagram
 

--- a/charts/artifact-keeper/README.md.gotmpl
+++ b/charts/artifact-keeper/README.md.gotmpl
@@ -174,6 +174,17 @@ memory footprint. Plan for roughly 1Gi to 2Gi of memory for a single-node
 OpenSearch pod (JVM heap plus off-heap and page cache) when you do enable it; see
 `opensearch.javaOpts` and the OpenSearch OOMKill note under Troubleshooting.
 
+In fleet mode the per-namespace `ResourceQuota` (see `fleet.guardrails.resourceQuota`)
+is sized from the preset and then grows to account for whichever optional
+components are enabled, so their pods and PVCs actually fit within the quota. If
+the preset only covered backend and web, enabling trivy, the scanner-adapter,
+OpenSearch, or DependencyTrack would push the namespace over its pod and memory
+limits and leave those workloads (and the database bootstrap Job) unschedulable.
+To pin any total by hand, set the matching key under
+`fleet.guardrails.quotaOverrides` (for example `limitsMemory: 32Gi`); an override
+replaces the computed value outright while the remaining totals stay
+component-aware.
+
 ### Component Diagram
 
 ```

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -331,28 +331,59 @@ Ingress host. Fleet instances derive it from fleet.host; otherwise ingress.host.
 {{- end -}}
 
 {{/*
+Formats an integer millicore count as a Kubernetes CPU quantity. Whole cores
+render bare (4000 -> "4"); anything else renders in millicores (9500 -> "9500m").
+*/}}
+{{- define "artifact-keeper.fleet.fmtCpu" -}}
+{{- $m := int . -}}
+{{- if eq (mod $m 1000) 0 -}}{{- div $m 1000 -}}{{- else -}}{{- printf "%dm" $m -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Formats an integer Mi count as a Kubernetes memory quantity. Whole gibibytes
+render in Gi (4096 -> "4Gi"); anything else renders in Mi (3840 -> "3840Mi").
+*/}}
+{{- define "artifact-keeper.fleet.fmtMem" -}}
+{{- $mi := int . -}}
+{{- if eq (mod $mi 1024) 0 -}}{{- printf "%dGi" (div $mi 1024) -}}{{- else -}}{{- printf "%dMi" $mi -}}{{- end -}}
+{{- end -}}
+
+{{/*
 Per-namespace guardrail sizing keyed on fleet.preset. Returns YAML with the
 ResourceQuota totals and the LimitRange container defaults/bounds for the
 selected preset. The quota totals sit above the summed backend+web
 requests/limits to leave headroom for init containers and the bootstrap Job.
+
+The base preset is expressed in canonical integer units (CPU in millicores,
+memory in Mi, pods and PVCs as counts) and formatted back to Kubernetes
+quantities at the end, so a preset with no optional components enabled renders
+exactly as the previous hardcoded table did.
+
+Enabled optional components (trivy, scannerAdapter, opensearch, dependencyTrack)
+add their own workload footprint to the totals so the quota can actually admit
+those pods (and PVCs). Without this, a preset sized only for backend+web leaves
+scanner and search pods (and the bootstrap Job) unschedulable behind the quota.
+
+fleet.guardrails.quotaOverrides replaces any individual computed total outright;
+only the keys present there take effect, the rest stay component-aware.
 */}}
 {{- define "artifact-keeper.fleet.guardrailSpec" -}}
 {{- $preset := default "small" .Values.fleet.preset -}}
 {{- $table := dict
   "small" (dict
-    "quota" (dict "requestsCpu" "1" "requestsMemory" "1Gi" "limitsCpu" "4" "limitsMemory" "4Gi" "pods" "12" "pvcs" "4")
+    "requestsCpu" 1000 "requestsMemory" 1024 "limitsCpu" 4000 "limitsMemory" 4096 "pods" 12 "pvcs" 4
     "limitRange" (dict
       "defaultRequest" (dict "cpu" "100m" "memory" "128Mi")
       "default" (dict "cpu" "500m" "memory" "512Mi")
       "max" (dict "cpu" "2" "memory" "2Gi")))
   "medium" (dict
-    "quota" (dict "requestsCpu" "2" "requestsMemory" "3Gi" "limitsCpu" "8" "limitsMemory" "8Gi" "pods" "20" "pvcs" "6")
+    "requestsCpu" 2000 "requestsMemory" 3072 "limitsCpu" 8000 "limitsMemory" 8192 "pods" 20 "pvcs" 6
     "limitRange" (dict
       "defaultRequest" (dict "cpu" "250m" "memory" "256Mi")
       "default" (dict "cpu" "1" "memory" "1Gi")
       "max" (dict "cpu" "3" "memory" "3Gi")))
   "large" (dict
-    "quota" (dict "requestsCpu" "4" "requestsMemory" "6Gi" "limitsCpu" "16" "limitsMemory" "16Gi" "pods" "30" "pvcs" "8")
+    "requestsCpu" 4000 "requestsMemory" 6144 "limitsCpu" 16000 "limitsMemory" 16384 "pods" 30 "pvcs" 8
     "limitRange" (dict
       "defaultRequest" (dict "cpu" "500m" "memory" "512Mi")
       "default" (dict "cpu" "2" "memory" "2Gi")
@@ -362,5 +393,51 @@ requests/limits to leave headroom for init containers and the bootstrap Job.
 {{- if not $spec -}}
 {{- fail (printf "fleet.preset=%q is not valid; use one of small, medium, large" $preset) -}}
 {{- end -}}
-{{- $spec | toYaml -}}
+{{/* Start from the base preset totals (requests.cpu carries no per-component
+     increment) and add each enabled component's footprint. */}}
+{{- $limitsCpu := $spec.limitsCpu -}}
+{{- $limitsMemory := $spec.limitsMemory -}}
+{{- $requestsMemory := $spec.requestsMemory -}}
+{{- $pods := $spec.pods -}}
+{{- $pvcs := $spec.pvcs -}}
+{{- if .Values.trivy.enabled -}}
+{{- $limitsCpu = add $limitsCpu 1000 -}}
+{{- $limitsMemory = add $limitsMemory 2048 -}}
+{{- $requestsMemory = add $requestsMemory 512 -}}
+{{- $pods = add $pods 2 -}}
+{{- end -}}
+{{- if .Values.scannerAdapter.enabled -}}
+{{- $limitsCpu = add $limitsCpu 500 -}}
+{{- $limitsMemory = add $limitsMemory 1024 -}}
+{{- $requestsMemory = add $requestsMemory 256 -}}
+{{- $pods = add $pods 2 -}}
+{{- end -}}
+{{- if .Values.opensearch.enabled -}}
+{{- $limitsCpu = add $limitsCpu 1000 -}}
+{{- $limitsMemory = add $limitsMemory 2048 -}}
+{{- $requestsMemory = add $requestsMemory 1024 -}}
+{{- $pods = add $pods 2 -}}
+{{- $pvcs = add $pvcs 1 -}}
+{{- end -}}
+{{- if .Values.dependencyTrack.enabled -}}
+{{- $limitsCpu = add $limitsCpu 2000 -}}
+{{- $limitsMemory = add $limitsMemory 4096 -}}
+{{- $requestsMemory = add $requestsMemory 1024 -}}
+{{- $pods = add $pods 3 -}}
+{{- $pvcs = add $pvcs 1 -}}
+{{- end -}}
+{{- $quota := dict
+    "requestsCpu" (include "artifact-keeper.fleet.fmtCpu" $spec.requestsCpu)
+    "requestsMemory" (include "artifact-keeper.fleet.fmtMem" $requestsMemory)
+    "limitsCpu" (include "artifact-keeper.fleet.fmtCpu" $limitsCpu)
+    "limitsMemory" (include "artifact-keeper.fleet.fmtMem" $limitsMemory)
+    "pods" $pods
+    "pvcs" $pvcs -}}
+{{- $ov := default dict .Values.fleet.guardrails.quotaOverrides -}}
+{{- range $k := list "requestsCpu" "requestsMemory" "limitsCpu" "limitsMemory" "pods" "pvcs" -}}
+{{- if hasKey $ov $k -}}
+{{- $_ := set $quota $k (index $ov $k) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "quota" $quota "limitRange" $spec.limitRange) | toYaml -}}
 {{- end -}}

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -1023,3 +1023,11 @@ fleet:
     searchNamespace: ""
     # -- Namespace of the shared scanner service (NetworkPolicy egress).
     scannerNamespace: ""
+    # -- Explicit ResourceQuota overrides. By default the quota is sized from the
+    # preset and grows to account for each enabled optional component (trivy,
+    # scannerAdapter, opensearch, dependencyTrack). Set any of these keys to
+    # replace the corresponding computed total outright; unset keys stay
+    # component-aware. Values are used verbatim as Kubernetes quantities, for
+    # example limitsMemory: 32Gi or pods: 40. Keys: requestsCpu, requestsMemory,
+    # limitsCpu, limitsMemory, pods, pvcs.
+    quotaOverrides: {}


### PR DESCRIPTION
## Summary

Fleet-mode ResourceQuota presets (`artifact-keeper.fleet.guardrailSpec` in `_helpers.tpl`) sized the per-namespace quota for the backend and web workloads only. They added nothing for the optional components (`trivy`, `scannerAdapter`, `opensearch`, `dependencyTrack`), so enabling any of them pushed the namespace over quota. On the medium preset (`limits.memory: 8Gi`) with `trivy` and `scannerAdapter` enabled, a web replica and the database bootstrap hook Job pod failed with `FailedCreate` / `exceeded quota`, leaving the release degraded.

This PR makes the quota component-aware and adds explicit overrides:

- **Component-aware sizing.** `guardrailSpec` now expresses the base preset in canonical integer units (CPU in millicores, memory in Mi) and adds each enabled component's footprint before formatting back to Kubernetes quantities. Increments per component: trivy `+1` CPU limit / `+2Gi` limits.memory / `+512Mi` requests.memory / `+2` pods; scannerAdapter `+0.5` CPU limit / `+1Gi` / `+256Mi` / `+2` pods; opensearch `+1` CPU limit / `+2Gi` / `+1Gi` / `+2` pods / `+1` PVC; dependencyTrack `+2` CPU limit / `+4Gi` / `+1Gi` / `+3` pods / `+1` PVC.
- **Explicit overrides.** New `fleet.guardrails.quotaOverrides` block (default `{}`). Any of `requestsCpu`, `requestsMemory`, `limitsCpu`, `limitsMemory`, `pods`, `pvcs` set there replaces the corresponding computed total outright; unset keys stay component-aware.

Backward compatibility is preserved: with no optional components enabled and no overrides set, the rendered quota (and the unchanged LimitRange) is byte-identical to `main` for all three presets. The chart version is bumped a minor (1.7.5 to 1.8.0) since this adds a value.

Docs: `values.yaml` comments document `quotaOverrides`, the README values table is regenerated via helm-docs, and a prose note was added to `README.md.gotmpl` under "Optional components".

## Verification

`helm lint` passes. Renders below use `--show-only templates/fleet-resourcequota.yaml`.

**(a) small preset, no optional components (identical to current main):**

```
spec:
  hard:
    requests.cpu: "1"
    requests.memory: "1Gi"
    limits.cpu: "4"
    limits.memory: "4Gi"
    pods: "12"
    persistentvolumeclaims: "4"
```

`diff` against the pre-change `main` render is empty for all three presets (quota and LimitRange).

**(b) medium preset, `trivy` + `scannerAdapter` enabled (limits.memory 8+2+1 = 11Gi, pods 20+2+2 = 24):**

```
spec:
  hard:
    requests.cpu: "2"
    requests.memory: "3840Mi"
    limits.cpu: "9500m"
    limits.memory: "11Gi"
    pods: "24"
    persistentvolumeclaims: "6"
```

**(c) medium preset, `fleet.guardrails.quotaOverrides.limitsMemory=32Gi` (override wins):**

```
spec:
  hard:
    requests.cpu: "2"
    requests.memory: "3Gi"
    limits.cpu: "8"
    limits.memory: "32Gi"
    pods: "20"
    persistentvolumeclaims: "6"
```

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [ ] N/A - documentation only

Rollback: revert the commit. With optional components disabled the quota is unchanged, so a revert is safe for those installs; installs relying on the larger component-aware quota would return to the previous (undersized) totals.

Closes #262
