### PR TITLE
fix(ci): run pull_request jobs on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
   detect-changes:
     name: Detect Changes
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
       pull-requests: read
@@ -30,7 +30,7 @@ jobs:
 
   terraform-validate:
     name: Terraform Validate (${{ matrix.env }})
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.terraform == 'true'
     permissions:
@@ -60,7 +60,7 @@ jobs:
 
   terraform-fmt:
     name: Terraform Format Check
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.terraform == 'true'
     permissions:
@@ -80,7 +80,7 @@ jobs:
 
   sonarcloud:
     name: SonarCloud Scan
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     # Skip on dependabot PRs: GitHub withholds secrets from dependabot
     # runs for security reasons, so SONAR_TOKEN is empty and the scan
     # always fails. SonarCloud provides no useful signal on dependency

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   template-validation:
     name: "Template & Validate (${{ matrix.variant }})"
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
     strategy:
@@ -104,7 +104,7 @@ jobs:
 
   verify-image-references:
     name: "Verify Image References (${{ matrix.variant }})"
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
     strategy:
@@ -229,7 +229,7 @@ jobs:
   version-check:
     name: Chart Version Check
     if: github.event_name == 'pull_request'
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
     steps:
@@ -265,7 +265,7 @@ jobs:
     #
     # Requires argocd/arc-beefy-runners-values.yaml to be deployed to the
     # cluster.
-    runs-on: ak-beefy-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-beefy-runners' }}
     needs: [lint, template-validation]
     permissions:
       contents: read

--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   verify:
     name: Verify helm-docs output
-    runs-on: ak-ci-runners
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Closes #275.

For `pull_request` events GitHub executes the workflow file from the PR, and helm-ci.yml's paths filter includes the workflow itself — so a fork PR could run arbitrary code on the self-hosted ARC runners inside the build cluster. `ct install` also executes PR-controlled charts in the k3d/DinD environment on the beefy runner.

Each job now picks its runner by event:

```yaml
runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-ci-runners' }}
```

Trusted code (`push`) keeps the fast self-hosted path; untrusted PR code gets the ephemeral, isolated GitHub-hosted runner. The k3d/DinD install test works on ubuntu-latest (slower, acceptable for untrusted code). Note: this PR's own checks still run under the pre-merge workflow — the protection takes effect once merged. The repo's fork-approval setting (UI-only, Settings → Actions) is worth setting to 'require approval for all outside collaborators' as a second layer regardless.