### PR TITLE
fix: refresh stale pins/examples and tighten terraform module security

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --target-branch main --charts charts/artifact-keeper/
 
       - name: Run helm lint
-        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f
+        run: helm lint charts/artifact-keeper/ --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test
 
   template-validation:
     name: "Template & Validate (${{ matrix.variant }})"
@@ -53,11 +53,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
           - variant: mesh-main
@@ -112,11 +112,11 @@ jobs:
       matrix:
         include:
           - variant: default
-            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
+            values_args: "--set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test"
           - variant: production
             values_args: "-f charts/artifact-keeper/values-production.yaml"
           - variant: staging
-            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test --set meilisearch.masterKey=1228c08daebf202dfa77b9d7b062c195d3ab1c8f"
+            values_args: "-f charts/artifact-keeper/values-staging.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test"
           - variant: smoke
             values_args: "-f charts/artifact-keeper/values-smoke.yaml --set backend.image.tag=dev --set web.image.tag=dev"
     steps:
@@ -263,8 +263,8 @@ jobs:
     # opensearch, dtrack) can stand up inside chart-testing's timeout window.
     # The regular ak-ci-runners pool (4 CPU / 8 Gi) is too tight.
     #
-    # Requires argocd/arc-beefy-runners-values.yaml to be deployed to the
-    # cluster.
+    # Requires the ak-beefy-runners ARC scale set to be deployed to the
+    # runner cluster; its configuration is maintained outside this repo.
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'ak-beefy-runners' }}
     needs: [lint, template-validation]
     permissions:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,8 +2,7 @@
 
 This repository holds the infrastructure for Artifact Keeper: the Helm chart
 that runs the application on Kubernetes, the Terraform that provisions the AWS
-platform underneath it, the ArgoCD manifests that drive delivery, and the CI
-runner and maintenance plumbing that supports the build pipeline. The
+platform underneath it, and the ArgoCD manifests that drive delivery. The
 application code lives in separate repositories (`artifact-keeper`,
 `artifact-keeper-web`, and so on); this repo only deploys the published
 container images.
@@ -20,15 +19,13 @@ install instructions, see `README.md`.
 | `charts/artifact-keeper/` | The umbrella Helm chart for the whole application (backend, web, edge, Postgres, OpenSearch, Trivy, scanner-adapter, DependencyTrack, ingress, secrets, policies). | Changing what runs in a cluster, adding a service, adjusting per-environment values. |
 | `terraform/modules/` | Reusable AWS building blocks: `vpc`, `eks`, `rds`, `s3`. | Changing how a class of AWS resource is built for every environment. |
 | `terraform/environments/` | One root module per environment (`dev`, `staging`, `production`) composing the four modules with environment-specific sizing. | Adding or resizing an environment's AWS footprint. |
-| `argocd/` | GitOps delivery: the `ApplicationSet`, `AppProject`, image updater config, ARC runner scale-set values, and the registry-cache / namespace-sweeper / mesh Applications. | Changing how ArgoCD syncs environments or how CI runners are shaped. |
+| `argocd/` | GitOps delivery: the `ApplicationSet`, `AppProject`, image updater config, and the mesh ApplicationSet. | Changing how ArgoCD syncs environments. |
 | `monitoring/` | `kube-prometheus-stack` values, a `PrometheusRule` with app alerts, and a Grafana dashboard JSON. | Changing alerting or dashboards. |
-| `e2e/` | In-cluster manifests for end-to-end and mesh tests (dind registry-mirror ConfigMap, mesh Job + RBAC, registry-cache static PVs, runner RBAC). | Changing the in-cluster test harness. |
-| `runner-images/` | Dockerfiles for the ARC runner images (`rust`, `e2e`). | Bumping runner toolchains. |
-| `ci-maintenance/` | The CI namespace-sweeper CronJob and its scoped RBAC. | Changing the leaked-namespace reclaim policy. |
+| `e2e/` | In-cluster manifests for mesh tests (mesh Job + RBAC). | Changing the in-cluster test harness. |
 | `aws-scripts/` | Single-node EC2 deployment: Docker install, a `docker-compose.yml`, an Nginx host config, and a first-boot secret-generation script. | Changing the all-in-one VM install path. |
 | `packer/` | A Packer template that bakes the single-node compose stack into an AMI. | Cutting a new prebuilt AMI. |
 | `demo/` | The `demo.artifactkeeper.com` compose file, reset script, and seed SQL. | Changing the public demo. |
-| `.github/` | Workflows (`helm-ci`, `helm-release`, `helm-docs`, `ci`, `runner-images`, `require-linked-issue`), the PR template, CODEOWNERS, Dependabot. | Changing CI or contribution rules. |
+| `.github/` | Workflows (`helm-ci`, `helm-release`, `helm-docs`, `ci`, `require-linked-issue`), the PR template, CODEOWNERS, Dependabot. | Changing CI or contribution rules. |
 
 There is no top-level git repo across the workspace; this directory is its own
 repository.
@@ -50,9 +47,8 @@ Values resolve in three layers, lowest precedence first:
    and backend/web/edge track the floating `dev` image tag. It is heavily
    commented and doubles as the reference for every tunable.
 2. Environment overlays layer on top: `values-staging.yaml`,
-   `values-production.yaml`, `values-smoke.yaml`, `values-mesh-main.yaml` /
-   `values-mesh-peer.yaml`, and `values-registry-cache.yaml`. Each only sets
-   what differs from the base.
+   `values-production.yaml`, `values-smoke.yaml`, and `values-mesh-main.yaml` /
+   `values-mesh-peer.yaml`. Each only sets what differs from the base.
 3. Deploy-time `--set` flags or ArgoCD Helm `parameters` win last. The mesh
    ApplicationSet, for example, injects `fullnameOverride` and peer identity
    this way.
@@ -183,7 +179,7 @@ Sync policy is deliberately not uniform:
 |-----|----------------|-------------|-----------|----------------|
 | dev | `main` | `values.yaml` | yes (selfHeal + prune) | digest |
 | staging | `main` | `values-staging.yaml` | yes (selfHeal + prune) | digest |
-| production | a chart tag (e.g. `v1.1.9`) | `values-production.yaml` | no (manual) | semver `~1.1` |
+| production | a chart tag (e.g. `artifact-keeper-1.9.1`) | `values-production.yaml` | no (manual) | semver `^1` |
 
 Promoting production is a deliberate act: bump the production element's
 `targetRevision` to the new chart tag and sync by hand. Dev and staging
@@ -196,11 +192,10 @@ CR (`argocd/image-updater-cr.yaml`) watches every Application matching
 `artifact-keeper-*` and `ak-*`, reading per-Application annotations for the
 image list and update strategy. Dev and staging resolve the `dev` tag to a
 concrete digest so rollouts are deterministic; production moves only within
-the `~1.1` semver range.
+the `^1` semver range (backend and web release on independent cadences, so
+only the major version is pinned).
 
-Two Applications live outside the main set: `registry-cache` (manual sync,
-pinned to a stable release, never auto-updated) and `ci-ns-sweeper` (auto-sync,
-sourced from `ci-maintenance/`). A separate mesh ApplicationSet
+A separate mesh ApplicationSet
 (`argocd/mesh-test-applicationset.yaml`) stands up four peer namespaces for
 replication testing, injecting per-instance identity via Helm parameters.
 
@@ -219,44 +214,19 @@ flowchart TD
     ghcr --> updater
     updater -->|digest pin| dev
     updater -->|digest pin| stg
-    updater -->|semver ~1.1| prod
+    updater -->|semver ^1| prod
 ```
 
 ## CI and runners
 
-CI runs on self-hosted Actions Runner Controller (ARC) v2 runner scale sets on
-a dedicated runner cluster. Three pools exist, each configured by a values
-file under `argocd/`:
-
-- `ak-ci-runners` (`arc-ci-runners-values.yaml`): the default pool for lint,
-  unit tests, and chart CI. Uses the `ak-runner-rust` image with a hostPath
-  `/cache` for shared cargo/sccache/npm caches. Max runners are capped (6) to
-  keep the per-runner memory limit from exhausting the node.
-- `ak-beefy-runners` (`arc-beefy-runners-values.yaml`): heavier jobs.
-- `ak-e2e-runners` (`arc-e2e-runners-values.yaml`): a Docker-in-Docker pool for
-  compose-based E2E stacks, using the `ak-runner-e2e` image with explicit
-  parallelism caps so cargo/nextest respect the pod's CPU limit instead of the
-  host core count.
-
-The scale-set chart is pinned to version `0.13.1` to match the ARC controller
-already on the cluster; newer chart minors render a CR the running controller
-silently drops. Both DinD pools route `docker.io` pulls through the in-cluster
-registry-cache via the `dind-registry-mirror` ConfigMap
-(`e2e/dind-registry-mirror-configmap.yaml`) and authenticate with a
-`dockerhub-pull` secret to lift anonymous rate limits.
-
-Runner images are built from `runner-images/{rust,e2e}/Dockerfile` and
-published by `.github/workflows/runner-images.yml` on merge to `main`. Base
-images and toolchains are pinned so the environment changes only through
-reviewed bumps.
-
-The namespace sweeper (`ci-maintenance/namespace-sweeper.yaml`) is a backstop
-for leaked CI test namespaces. It is an hourly CronJob that deletes namespaces
-matching an approved prefix (`smoke-self-`, `test-self-`) older than four
-hours, guarded by a protected-substring denylist. The blast radius is
-constrained in the script, not by RBAC, because namespace verbs cannot be
-name-scoped. It ships as the `ci-ns-sweeper` ArgoCD Application with self-heal
-on.
+CI selects its runner by event. `pull_request` jobs run on GitHub-hosted
+runners (`ubuntu-latest`) so untrusted PR code gets an ephemeral, isolated
+environment; `push` jobs run on self-hosted Actions Runner Controller (ARC)
+scale sets (`ak-ci-runners`, `ak-beefy-runners`) for speed and capacity. The
+`helm-ci` install test uses the larger `ak-beefy-runners` pool so the k3d
+cluster plus the full chart fit inside chart-testing's timeout window. The
+runner scale-set configuration and runner images are maintained outside this
+repository; the workflows here only select pools by label.
 
 ## Key invariants
 
@@ -279,6 +249,3 @@ on.
   promotion is a `targetRevision` bump plus a hand-triggered sync.
 - **Per-component scheduling replaces global.** It does not merge; there is no
   way to opt a single component out of global scheduling without restating it.
-- **The registry-cache and mesh instances have independent lifecycles.** Never
-  point the registry cache at `dev` or `latest`, and never enable image-updater
-  on it; a broken cache breaks every CI pull.

--- a/argocd/applicationset.yaml
+++ b/argocd/applicationset.yaml
@@ -36,10 +36,13 @@ spec:
           - env: production
             namespace: artifact-keeper-prod
             valuesFile: values-production.yaml
-            # Production tracks a specific release tag. Update this value
-            # to promote a new version (e.g., v1.2.0). Sync is manual.
-            targetRevision: v1.1.9
-            imageTag: ~1.1
+            # Production tracks a specific chart release tag. Update this
+            # value to promote a new version (e.g., artifact-keeper-1.9.1).
+            # Sync is manual.
+            targetRevision: artifact-keeper-1.9.1
+            # Backend and web release on independent cadences and only the
+            # MAJOR version has to align, so allow any 1.x image.
+            imageTag: ^1
             imageUpdateStrategy: semver
             autoSync: "false"
   template:

--- a/aws-scripts/02-artifact-keeper.sh
+++ b/aws-scripts/02-artifact-keeper.sh
@@ -25,20 +25,23 @@ cp "${SRC}/first-boot.sh" "${AK_DIR}/first-boot.sh"
 cp "${SRC}/nginx-host.conf" "${AK_DIR}/nginx-host.conf"
 chmod +x "${AK_DIR}/first-boot.sh"
 
-# Create data directories
-mkdir -p /data/{postgres,meilisearch,storage,trivy-cache}
+# Create data directories. trivy-cache must be writable by the nobody user
+# the trivy container runs as (65534).
+mkdir -p /data/{postgres,opensearch,storage}
+install -d -o 65534 -g 65534 /data/trivy-cache
 
 # Pull images now so first boot is fast
-AK_VERSION="${ARTIFACT_KEEPER_VERSION:-latest}"
+BACKEND_VERSION="${ARTIFACT_KEEPER_BACKEND_VERSION:-${ARTIFACT_KEEPER_VERSION:-1.6.0}}"
+WEB_VERSION="${ARTIFACT_KEEPER_WEB_VERSION:-1.5.8}"
 cd "${AK_DIR}"
 
-# Write the .env with the version tag
+# Write the .env with the version tags
 cat > "${AK_DIR}/.env" <<EOF
-ARTIFACT_KEEPER_VERSION=${AK_VERSION}
+ARTIFACT_KEEPER_BACKEND_VERSION=${BACKEND_VERSION}
+ARTIFACT_KEEPER_WEB_VERSION=${WEB_VERSION}
 # Populated by first-boot:
 DB_PASSWORD=changeme
 JWT_SECRET=changeme
-MEILI_MASTER_KEY=changeme
 EOF
 chmod 600 "${AK_DIR}/.env"
 

--- a/aws-scripts/docker-compose.yml
+++ b/aws-scripts/docker-compose.yml
@@ -41,14 +41,17 @@ services:
       retries: 10
 
   trivy:
-    image: aquasec/trivy:latest
+    image: aquasec/trivy:0.72.0
     restart: always
-    command: ["server", "--listen", "0.0.0.0:8090"]
+    # Run as the nobody user instead of the image's default root. Server
+    # mode only needs a writable cache dir, which the volume below provides.
+    user: "65534:65534"
+    command: ["server", "--listen", "0.0.0.0:8090", "--cache-dir", "/cache/trivy"]
     volumes:
-      - /data/trivy-cache:/root/.cache/trivy
+      - /data/trivy-cache:/cache/trivy
 
   backend:
-    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_BACKEND_VERSION:-1.6.0}
     restart: always
     environment:
       DATABASE_URL: postgresql://artifact_keeper:${DB_PASSWORD}@postgres:5432/artifact_keeper
@@ -71,7 +74,7 @@ services:
         condition: service_healthy
 
   web:
-    image: ghcr.io/artifact-keeper/artifact-keeper-web:${ARTIFACT_KEEPER_VERSION:-latest}
+    image: ghcr.io/artifact-keeper/artifact-keeper-web:${ARTIFACT_KEEPER_WEB_VERSION:-1.5.8}
     restart: always
     environment:
       BACKEND_URL: http://backend:8080

--- a/aws-scripts/first-boot.sh
+++ b/aws-scripts/first-boot.sh
@@ -17,16 +17,14 @@ echo "==> Artifact Keeper first-boot configuration"
 # -------------------------------------------------------------------------
 DB_PASSWORD=$(openssl rand -hex 24)
 JWT_SECRET=$(openssl rand -hex 32)
-MEILI_KEY=$(openssl rand -hex 24)
 
 # -------------------------------------------------------------------------
 # 2. Write .env for Docker Compose
 # -------------------------------------------------------------------------
 cat > "${AK_DIR}/.env" <<EOF
-ARTIFACT_KEEPER_VERSION=$(grep ARTIFACT_KEEPER_VERSION "${AK_DIR}/.env" | cut -d= -f2)
+$(grep -E '^ARTIFACT_KEEPER_' "${AK_DIR}/.env")
 DB_PASSWORD=${DB_PASSWORD}
 JWT_SECRET=${JWT_SECRET}
-MEILI_MASTER_KEY=${MEILI_KEY}
 EOF
 chmod 600 "${AK_DIR}/.env"
 
@@ -93,7 +91,6 @@ cat > "$CREDS_FILE" <<CREDS
 Access URL: ${DOMAIN:+https://${DOMAIN}}${DOMAIN:-http://${PUBLIC_IP:-YOUR_IP}}
 
 Database Password:  ${DB_PASSWORD}
-Meilisearch Key:    ${MEILI_KEY}
 JWT Secret:         ${JWT_SECRET}
 
 Docker Compose Dir: ${AK_DIR}

--- a/charts/artifact-keeper/values-production.yaml
+++ b/charts/artifact-keeper/values-production.yaml
@@ -11,7 +11,9 @@
 backend:
   replicaCount: 3
   image:
-    tag: "1.2.0"
+    # Tracks the latest published backend release (see the IMAGE TAGS note in
+    # values.yaml — backend and web release on independent cadences).
+    tag: "1.6.0"
   env:
     RUST_LOG: "info"
     ENVIRONMENT: "production"
@@ -49,7 +51,7 @@ backend:
 web:
   replicaCount: 3
   image:
-    tag: "1.2.0"
+    tag: "1.5.8"
   resources:
     requests:
       cpu: 500m

--- a/packer/artifact-keeper.pkr.hcl
+++ b/packer/artifact-keeper.pkr.hcl
@@ -13,8 +13,8 @@ packer {
 
 variable "artifact_keeper_version" {
   type        = string
-  default     = "latest"
-  description = "Docker image tag to bake into the AMI (e.g. latest, 0.2.0, main)."
+  default     = "1.6.0"
+  description = "Backend image tag to bake into the AMI (the compose stack's web image is pinned separately in aws-scripts/docker-compose.yml)."
 }
 
 variable "aws_region" {
@@ -39,7 +39,7 @@ variable "ami_regions" {
 
 source "amazon-ebs" "artifact-keeper" {
   ami_name        = "artifact-keeper-${var.artifact_keeper_version}-{{timestamp}}"
-  ami_description = "Artifact Keeper ${var.artifact_keeper_version} - open-source artifact registry with PostgreSQL, Meilisearch, and Trivy."
+  ami_description = "Artifact Keeper ${var.artifact_keeper_version} - open-source artifact registry with PostgreSQL, OpenSearch, and Trivy."
   instance_type   = var.instance_type
   region          = var.aws_region
   ami_regions     = var.ami_regions
@@ -86,7 +86,7 @@ build {
 
   # Upload scripts and compose file
   provisioner "file" {
-    source      = "${path.root}/../scripts/"
+    source      = "${path.root}/../aws-scripts/"
     destination = "/tmp/ak-scripts"
   }
 
@@ -98,9 +98,9 @@ build {
     ]
     execute_command = "chmod +x {{ .Path }}; sudo -E {{ .Path }}"
     scripts = [
-      "${path.root}/../scripts/01-docker.sh",
-      "${path.root}/../scripts/02-artifact-keeper.sh",
-      "${path.root}/../scripts/99-cleanup.sh",
+      "${path.root}/../aws-scripts/01-docker.sh",
+      "${path.root}/../aws-scripts/02-artifact-keeper.sh",
+      "${path.root}/../aws-scripts/99-cleanup.sh",
     ]
   }
 }

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -97,6 +97,20 @@ resource "aws_eks_cluster" "this" {
     security_group_ids      = [aws_security_group.cluster.id]
     endpoint_private_access = true
     endpoint_public_access  = var.endpoint_public_access
+    public_access_cidrs     = var.endpoint_public_access_cidrs
+  }
+
+  # Optional envelope encryption of Kubernetes secrets with a customer-managed
+  # KMS key. Off by default for backwards compatibility; see the
+  # secrets_encryption_key_arn variable.
+  dynamic "encryption_config" {
+    for_each = var.secrets_encryption_key_arn != "" ? [var.secrets_encryption_key_arn] : []
+    content {
+      provider {
+        key_arn = encryption_config.value
+      }
+      resources = ["secrets"]
+    }
   }
 
   tags = var.tags

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -39,6 +39,18 @@ variable "endpoint_public_access" {
   default     = true
 }
 
+variable "endpoint_public_access_cidrs" {
+  description = "CIDR blocks allowed to reach the public API server endpoint when endpoint_public_access is true. Defaults to fully open for backwards compatibility; restrict this to operator/VPN ranges in real deployments."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "secrets_encryption_key_arn" {
+  description = "ARN of a customer-managed KMS key used for envelope encryption of Kubernetes secrets (EKS encryption_config). Empty (the default) leaves envelope encryption off. Enabling it on an existing cluster is irreversible — the key must not be deleted afterwards."
+  type        = string
+  default     = ""
+}
+
 variable "node_groups" {
   description = "Map of managed node group configurations"
   type = map(object({

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -71,14 +71,22 @@ resource "aws_security_group_rule" "rds_ingress_eks" {
   description              = "Allow PostgreSQL access from EKS cluster nodes"
 }
 
+# Egress is scoped to PostgreSQL inside the VPC: the only outbound traffic the
+# instance originates is streaming replication to a Multi-AZ standby (or read
+# replica) in the same VPC. AWS-managed maintenance traffic is exempt from
+# security group rules, so nothing broader is needed.
+data "aws_vpc" "this" {
+  id = var.vpc_id
+}
+
 resource "aws_security_group_rule" "rds_egress" {
   type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [data.aws_vpc.this.cidr_block]
   security_group_id = aws_security_group.rds.id
-  description       = "Allow all egress"
+  description       = "Allow PostgreSQL egress within the VPC (Multi-AZ replication)"
 }
 
 ################################################################################

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -214,13 +214,18 @@ data "aws_iam_policy_document" "flow_log_publish" {
   statement {
     effect = "Allow"
     actions = [
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
     ]
-    resources = ["*"]
+    # Scoped to the log group this module creates (and its log streams, which
+    # live under the "<group-arn>:*" resource). logs:CreateLogGroup is
+    # deliberately omitted: the group is module-managed.
+    resources = [
+      aws_cloudwatch_log_group.flow_log[0].arn,
+      "${aws_cloudwatch_log_group.flow_log[0].arn}:*",
+    ]
   }
 }
 


### PR DESCRIPTION
Closes #281

## What changed

**Stale version pins**
- `charts/artifact-keeper/values-production.yaml`: backend/web image pins `1.2.0` → `1.6.0`/`1.5.8`, matching the chart defaults in `values.yaml` and the currently published images. Kept explicit pins (rather than deleting them) because `values.yaml` documents overlays pinning their own tags as the established pattern.
- `argocd/applicationset.yaml`: production `targetRevision` `v1.1.9` → `artifact-keeper-1.9.1` (the current chart release tag, per the `helm-release` tagging convention) and image-updater range `~1.1` → `^1`. Backend and web release on independent cadences with only the MAJOR version required to align, so a minor-bound range no longer fits either component.

**Floating/unpinned images in the single-node path**
- `aws-scripts/docker-compose.yml`: `aquasec/trivy:latest` → `aquasec/trivy:0.72.0` (current upstream release), running as `nobody` (65534) instead of root with an explicit `--cache-dir` on the mounted volume; `02-artifact-keeper.sh` creates that volume owned by 65534.
- The shared `ARTIFACT_KEEPER_VERSION:-latest` default is split into `ARTIFACT_KEEPER_BACKEND_VERSION:-1.6.0` / `ARTIFACT_KEEPER_WEB_VERSION:-1.5.8`. A single default can't work — web has no `1.6.0` image (verified against ghcr: backend `1.6.0` → 200, web `1.6.0` → 404), matching the chart's independent-cadence pinning. The packer-passed `ARTIFACT_KEEPER_VERSION` still works (maps to the backend version).

**Dead references**
- `ARCHITECTURE.md`: removed `runner-images/`, `ci-maintenance/`, `values-registry-cache.yaml`, `runner-images.yml`, and the registry-cache/namespace-sweeper Applications (all removed in a3816d9); rewrote the "CI and runners" section to describe the current event-based runner selection; updated the production sync table/diagram to the new tag and semver range.
- `.github/workflows/helm-ci.yml`: dropped `--set meilisearch.masterKey=...` (5 places) — the chart has no Meilisearch component; fixed the comment pointing at the removed `argocd/arc-beefy-runners-values.yaml`.
- `aws-scripts/`: removed the dead `MEILI_MASTER_KEY` generation/plumbing and fixed `/data/meilisearch` → `/data/opensearch` in the data-dir creation.

**Broken packer build**
- `packer/artifact-keeper.pkr.hcl`: provisioners referenced `${path.root}/../scripts/` which does not exist; pointed at `aws-scripts/`. Default AMI version `latest` → `1.6.0`, and the AMI description no longer mentions Meilisearch.

**Terraform security**
- `rds`: all-protocol egress to `0.0.0.0/0` → TCP 5432 to the VPC CIDR only (covers Multi-AZ replication; commented why nothing broader is needed).
- `vpc`: flow-log IAM policy `resources = ["*"]` → the module's log group ARN + its streams; dropped unneeded `logs:CreateLogGroup` (the group is module-managed).
- `eks`: new optional `secrets_encryption_key_arn` (customer KMS key for envelope encryption of Kubernetes secrets; empty = off, previous behavior) and `endpoint_public_access_cidrs` (defaults to `0.0.0.0/0` for backwards compatibility). Environment root modules are untouched.

## Validation

- `terraform fmt -recursive terraform/` clean; `terraform init -backend=false` + `terraform validate` passes for `modules/eks`, `modules/rds`, `modules/vpc`, and the `dev` environment root.
- `helm template` with `values-production.yaml` renders `backend:1.6.0` / `web:1.5.8`; both tags (and trivy `0.72.0`) verified to exist on their registries.
- `packer validate` passes; `bash -n` on both changed scripts; `docker compose config` parses.
- No `Chart.yaml` version bump — values-only overlay change; maintainers can cut the next chart release on their normal cadence.

## Notes

- `demo/docker-compose.demo.yml` also defaults `ARTIFACT_KEEPER_VERSION` to `latest`, but that file documents `latest` as an intentional "latest stable release" default for the demo; left alone.

## CI notes

- **GitGuardian Security Checks (fail)** — false positive: the flagged "secrets" are the pre-existing `ci-nonprod-jwt-...` placeholder and `ci-test` password already on `main` in `helm-ci.yml`. Removing the `meilisearch.masterKey` set rewrites those lines, so the same strings reappear on added lines and GitGuardian counts them as new occurrences. No new secret is introduced; the incidents can be dismissed in the dashboard.
