### PR TITLE
fix(chart): grow fleet ResourceQuota requests.cpu per enabled component

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,7 +10,7 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.9.2
+version: 1.9.3
 appVersion: "1.6.0"
 home: https://artifactkeeper.com
 sources:

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 ## TL;DR
 

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -468,26 +468,33 @@ only the keys present there take effect, the rest stay component-aware.
 {{- if not $spec -}}
 {{- fail (printf "fleet.preset=%q is not valid; use one of small, medium, large" $preset) -}}
 {{- end -}}
-{{/* Start from the base preset totals (requests.cpu carries no per-component
-     increment) and add each enabled component's footprint. */}}
+{{/* Start from the base preset totals and add each enabled component's
+     footprint. requests.cpu must grow too: the base preset covers only the
+     core workload, so enabling an optional component otherwise wedges the
+     namespace (new pods forbidden by the quota; observed live when search
+     was enabled on a medium tenant). */}}
+{{- $requestsCpu := $spec.requestsCpu -}}
 {{- $limitsCpu := $spec.limitsCpu -}}
 {{- $limitsMemory := $spec.limitsMemory -}}
 {{- $requestsMemory := $spec.requestsMemory -}}
 {{- $pods := $spec.pods -}}
 {{- $pvcs := $spec.pvcs -}}
 {{- if .Values.trivy.enabled -}}
+{{- $requestsCpu = add $requestsCpu 250 -}}
 {{- $limitsCpu = add $limitsCpu 1000 -}}
 {{- $limitsMemory = add $limitsMemory 2048 -}}
 {{- $requestsMemory = add $requestsMemory 512 -}}
 {{- $pods = add $pods 2 -}}
 {{- end -}}
 {{- if .Values.scannerAdapter.enabled -}}
+{{- $requestsCpu = add $requestsCpu 100 -}}
 {{- $limitsCpu = add $limitsCpu 500 -}}
 {{- $limitsMemory = add $limitsMemory 1024 -}}
 {{- $requestsMemory = add $requestsMemory 256 -}}
 {{- $pods = add $pods 2 -}}
 {{- end -}}
 {{- if .Values.opensearch.enabled -}}
+{{- $requestsCpu = add $requestsCpu 250 -}}
 {{- $limitsCpu = add $limitsCpu 1000 -}}
 {{- $limitsMemory = add $limitsMemory 2048 -}}
 {{- $requestsMemory = add $requestsMemory 1024 -}}
@@ -495,6 +502,7 @@ only the keys present there take effect, the rest stay component-aware.
 {{- $pvcs = add $pvcs 1 -}}
 {{- end -}}
 {{- if .Values.dependencyTrack.enabled -}}
+{{- $requestsCpu = add $requestsCpu 500 -}}
 {{- $limitsCpu = add $limitsCpu 2000 -}}
 {{- $limitsMemory = add $limitsMemory 4096 -}}
 {{- $requestsMemory = add $requestsMemory 1024 -}}
@@ -502,7 +510,7 @@ only the keys present there take effect, the rest stay component-aware.
 {{- $pvcs = add $pvcs 1 -}}
 {{- end -}}
 {{- $quota := dict
-    "requestsCpu" (include "artifact-keeper.fleet.fmtCpu" $spec.requestsCpu)
+    "requestsCpu" (include "artifact-keeper.fleet.fmtCpu" $requestsCpu)
     "requestsMemory" (include "artifact-keeper.fleet.fmtMem" $requestsMemory)
     "limitsCpu" (include "artifact-keeper.fleet.fmtCpu" $limitsCpu)
     "limitsMemory" (include "artifact-keeper.fleet.fmtMem" $limitsMemory)


### PR DESCRIPTION
Closes #286.

The `fleet.guardrailSpec` helper sized the fleet ResourceQuota for enabled optional components in every dimension except requests.cpu, which always rendered the base preset value. Enabling search/Trivy/scanner/dtrack can therefore push the namespace over its own quota — observed live: a medium tenant wedged Synced/Degraded when search was enabled.

Render evidence after the fix:
- medium + scanning (no search): 2000m → **2350m**
- medium + scanning + search: 2000m → **2600m**
- default render (all optional on): 3100m, lint clean

Increments mirror each component's actual CPU request. quotaOverrides.requestsCpu remains available as an override.