### PR TITLE
fix(chart): size fleet quota limits.cpu to pod limits plus rollout surge

### DIFF
--- a/charts/artifact-keeper/Chart.yaml
+++ b/charts/artifact-keeper/Chart.yaml
@@ -10,7 +10,7 @@ apiVersion: v2
 name: artifact-keeper
 description: Enterprise artifact registry supporting 45+ package formats
 type: application
-version: 1.9.3
+version: 1.9.4
 appVersion: "1.6.0"
 home: https://artifactkeeper.com
 sources:

--- a/charts/artifact-keeper/README.md
+++ b/charts/artifact-keeper/README.md
@@ -1,6 +1,6 @@
 # artifact-keeper
 
-![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.9.4](https://img.shields.io/badge/Version-1.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 ## TL;DR
 

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -472,12 +472,16 @@ only the keys present there take effect, the rest stay component-aware.
      footprint. requests.cpu must grow too: the base preset covers only the
      core workload, so enabling an optional component otherwise wedges the
      namespace (new pods forbidden by the quota; observed live when search
-     was enabled on a medium tenant). */}}
+     was enabled on a medium tenant). limits.cpu increments match each
+     component's actual pod limit, plus headroom for ONE backend pod and
+     ONE web pod: a RollingUpdate surge otherwise exceeds the quota
+     mid-rollout and wedges the deployment (observed live on the same
+     tenant once it could finally schedule OpenSearch). */}}
 {{- $requestsCpu := $spec.requestsCpu -}}
-{{- $limitsCpu := $spec.limitsCpu -}}
+{{- $limitsCpu := add $spec.limitsCpu 3000 -}}
 {{- $limitsMemory := $spec.limitsMemory -}}
 {{- $requestsMemory := $spec.requestsMemory -}}
-{{- $pods := $spec.pods -}}
+{{- $pods := add $spec.pods 2 -}}
 {{- $pvcs := $spec.pvcs -}}
 {{- if .Values.trivy.enabled -}}
 {{- $requestsCpu = add $requestsCpu 250 -}}
@@ -488,14 +492,14 @@ only the keys present there take effect, the rest stay component-aware.
 {{- end -}}
 {{- if .Values.scannerAdapter.enabled -}}
 {{- $requestsCpu = add $requestsCpu 100 -}}
-{{- $limitsCpu = add $limitsCpu 500 -}}
+{{- $limitsCpu = add $limitsCpu 1000 -}}
 {{- $limitsMemory = add $limitsMemory 1024 -}}
 {{- $requestsMemory = add $requestsMemory 256 -}}
 {{- $pods = add $pods 2 -}}
 {{- end -}}
 {{- if .Values.opensearch.enabled -}}
 {{- $requestsCpu = add $requestsCpu 250 -}}
-{{- $limitsCpu = add $limitsCpu 1000 -}}
+{{- $limitsCpu = add $limitsCpu 2000 -}}
 {{- $limitsMemory = add $limitsMemory 2048 -}}
 {{- $requestsMemory = add $requestsMemory 1024 -}}
 {{- $pods = add $pods 2 -}}


### PR DESCRIPTION
Closes #287. Follow-up to #286. The limits.cpu component increments didn't match actual pod limits (scannerAdapter 500m vs 1000m actual, opensearch 1000m vs 2000m actual) and there was no RollingUpdate surge headroom — observed live: a medium tenant wedged mid-rollout when a surge web pod pushed limits.cpu over quota (used 10 cores of 10500m, pod needed 1 more).

Changes: increments now match actual pod limits (scanner 1000m, opensearch 2000m), plus a flat 3000m surge allowance (one backend pod + one web pod) and +2 pods. Render evidence: medium + scanning + search → limits.cpu 15000m (was 10500m), requests.cpu 2600m (unchanged from #286), pods 28. Lint clean. quotaOverrides still available.