### PR TITLE
feat(chart): OpenShift support (Routes, arbitrary-UID overlay)

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -64,6 +64,8 @@ jobs:
             values_args: "-f charts/artifact-keeper/values-mesh-main.yaml"
           - variant: mesh-peer
             values_args: "-f charts/artifact-keeper/values-mesh-peer.yaml"
+          - variant: openshift
+            values_args: "-f charts/artifact-keeper/values-openshift.yaml --set secrets.jwtSecret=ci-nonprod-jwt-76ce00933faca9df20b027521d0b2a63a9b264c7155f7bd7 --set postgres.auth.password=ci-test"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/charts/artifact-keeper/templates/_helpers.tpl
+++ b/charts/artifact-keeper/templates/_helpers.tpl
@@ -528,3 +528,59 @@ only the keys present there take effect, the rest stay component-aware.
 {{- end -}}
 {{- (dict "quota" $quota "limitRange" $spec.limitRange) | toYaml -}}
 {{- end -}}
+
+{{/*
+The native package-format path prefixes that route to the backend, as a
+space-separated string. Consumed by both the Ingress (ingress.yaml) and the
+OpenShift Routes (route.yaml) via `splitList " " (trim ...)`, so the two never
+drift out of sync. Does NOT include /api, /v2, /health, or /ready — those carry
+their own pathType/handling in each template.
+*/}}
+{{- define "artifact-keeper.backendFormatPaths" -}}
+/maven /npm /pypi /nuget /cargo /gems /go /helm /debian /rpm /alpine /composer /conan /conda /swift /terraform /cocoapods /hex /pub /lfs /ivy /chef /puppet /ansible /cran /huggingface /jetbrains /vscode /proto /incus /ext
+{{- end -}}
+
+{{/*
+Render one OpenShift Route. An OpenShift Route targets a single Service, so the
+single-host/many-paths Ingress is expressed as one Route per path; the HAProxy
+router does longest-path-prefix matching, so specific backend paths win over the
+"/" web catch-all. Call with a dict:
+  root        - the top-level "." (for labels)
+  name        - metadata.name
+  host        - shared external hostname (may be empty to let the router assign)
+  path        - spec.path prefix
+  service     - target Service name
+  targetPort  - service port name or number
+  annotations - route annotations map
+  tls         - .Values.route.tls (enabled/termination/insecureEdgeTerminationPolicy)
+*/}}
+{{- define "artifact-keeper.routeObject" -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "artifact-keeper.labels" .root | nindent 4 }}
+    app.kubernetes.io/component: route
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .host }}
+  host: {{ .host }}
+  {{- end }}
+  path: {{ .path }}
+  to:
+    kind: Service
+    name: {{ .service }}
+    weight: 100
+  port:
+    targetPort: {{ .targetPort }}
+  {{- if .tls.enabled }}
+  tls:
+    termination: {{ .tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end -}}

--- a/charts/artifact-keeper/templates/fleet-db-bootstrap-job.yaml
+++ b/charts/artifact-keeper/templates/fleet-db-bootstrap-job.yaml
@@ -45,10 +45,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- /*
+        Pod securityContext is values-driven so an OpenShift overlay can blank
+        runAsUser/fsGroup and let the restricted-v2 SCC assign an arbitrary
+        UID. The default keeps the postgres image's own uid/gid 70 for plain
+        Kubernetes. The client tools only write to HOME=/tmp (an emptyDir), so
+        they run fine under any UID.
+      */}}
+      {{- with .Values.fleet.externalDatabaseBootstrap.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 70
         fsGroup: 70
+      {{- end }}
       containers:
         - name: db-bootstrap
           image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"

--- a/charts/artifact-keeper/templates/ingress.yaml
+++ b/charts/artifact-keeper/templates/ingress.yaml
@@ -89,7 +89,7 @@ spec:
           # Native package format handlers — route directly to backend
           {{- $backendSvc := printf "%s-backend" (include "artifact-keeper.fullname" .) }}
           {{- $backendPort := .Values.backend.service.httpPort }}
-          {{- range list "/maven" "/npm" "/pypi" "/nuget" "/cargo" "/gems" "/go" "/helm" "/debian" "/rpm" "/alpine" "/composer" "/conan" "/conda" "/swift" "/terraform" "/cocoapods" "/hex" "/pub" "/lfs" "/ivy" "/chef" "/puppet" "/ansible" "/cran" "/huggingface" "/jetbrains" "/vscode" "/proto" "/incus" "/ext" }}
+          {{- range (splitList " " (trim (include "artifact-keeper.backendFormatPaths" .))) }}
           - path: {{ . }}
             pathType: Prefix
             backend:

--- a/charts/artifact-keeper/templates/route.yaml
+++ b/charts/artifact-keeper/templates/route.yaml
@@ -1,0 +1,47 @@
+{{/*
+=============================================================================
+OpenShift Route (alternative to Ingress)
+=============================================================================
+Renders only when route.enabled is set, which is the OpenShift path: the
+platform's HAProxy router serves Routes rather than a Kubernetes Ingress
+controller. Mutually exclusive with ingress.enabled in practice; enabling both
+would publish the same hostname twice.
+
+The Ingress puts every path on one host and fans them out to the backend, web,
+and (optionally) Dependency-Track services. A Route targets a single Service,
+so that fan-out becomes one Route per path prefix, all sharing route.host. The
+router matches the longest path prefix, so the specific backend/dtrack paths
+win over the "/" web catch-all.
+
+This file is a starting point; review it against your cluster's router,
+certificate, and hostname policies before production use.
+=============================================================================
+*/}}
+{{- if .Values.route.enabled }}
+{{- $fullName := include "artifact-keeper.fullname" . -}}
+{{- $host := default (include "artifact-keeper.ingressHost" .) .Values.route.host -}}
+{{- $common := dict "root" . "host" $host "annotations" (default dict .Values.route.annotations) "tls" .Values.route.tls -}}
+{{- $backendPaths := concat (list "/api" "/v2" "/health" "/ready") (splitList " " (trim (include "artifact-keeper.backendFormatPaths" .))) -}}
+{{- range $path := $backendPaths }}
+---
+{{ include "artifact-keeper.routeObject" (merge (dict
+    "name" (printf "%s-route-%s" $fullName (trimPrefix "/" $path))
+    "path" $path
+    "service" (printf "%s-backend" $fullName)
+    "targetPort" "http") $common) }}
+{{- end }}
+{{- if and .Values.dependencyTrack.enabled .Values.route.dtrack.enabled }}
+---
+{{ include "artifact-keeper.routeObject" (merge (dict
+    "name" (printf "%s-route-dtrack" $fullName)
+    "path" "/dtrack"
+    "service" (printf "%s-dtrack" $fullName)
+    "targetPort" 8080) $common) }}
+{{- end }}
+---
+{{ include "artifact-keeper.routeObject" (merge (dict
+    "name" (printf "%s-route-web" $fullName)
+    "path" "/"
+    "service" (printf "%s-web" $fullName)
+    "targetPort" "http") $common) }}
+{{- end }}

--- a/charts/artifact-keeper/values-openshift.yaml
+++ b/charts/artifact-keeper/values-openshift.yaml
@@ -1,0 +1,139 @@
+# =============================================================================
+# EXAMPLE CONFIGURATION - Getting Started Template
+# =============================================================================
+# This file is provided as a starting point for deployments. It should be
+# reviewed and modified to match your specific infrastructure requirements,
+# security policies, and operational needs before use in production.
+# =============================================================================
+
+# OpenShift overlay.
+#
+# Install with:
+#   helm install ak charts/artifact-keeper \
+#     -f charts/artifact-keeper/values-openshift.yaml
+#
+# What this overlay does:
+#   1. Serves the app through OpenShift Routes instead of a Kubernetes Ingress.
+#   2. Removes every hardcoded runAsUser/fsGroup so the default `restricted-v2`
+#      SCC can assign an arbitrary UID (always a member of GID 0). Setting a key
+#      to null deletes it from the base values (Helm 3 coalesce semantics), so
+#      only runAsNonRoot is left behind.
+#   3. Drops the OpenSearch root chown init container, relying on the
+#      platform-assigned fsGroup to make the data volume group-writable.
+#
+# The application tier (backend, web, edge, trivy, scanner-adapter,
+# Dependency-Track) uses UBI / arbitrary-UID-friendly images and runs cleanly
+# under restricted-v2 with the settings below. The two BUNDLED STATEFUL
+# services need attention before a strict cluster will run them; see the
+# postgres and opensearch notes further down.
+
+# --- Networking: Routes, not Ingress -----------------------------------------
+ingress:
+  enabled: false
+
+route:
+  enabled: true
+  # Empty host lets the OpenShift router generate a hostname per Route. Set this
+  # to your apps-domain hostname (e.g. artifacts.apps.<cluster>.example.com) to
+  # pin it, and add the matching Route/edge certificate via route.annotations.
+  host: ""
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  # Publish Dependency-Track only if you front it with your own auth.
+  dtrack:
+    enabled: false
+
+# --- Storage -----------------------------------------------------------------
+global:
+  # Empty uses the cluster's default StorageClass. On OpenShift Data Foundation
+  # that is typically ocs-storagecluster-ceph-rbd (block) or -cephfs (file).
+  # Set explicitly if the default is not what you want for the PVCs below.
+  storageClass: ""
+
+# --- Object storage: point the backend at ODF / NooBaa (optional) ------------
+# OpenShift Data Foundation exposes an S3-compatible endpoint (NooBaa / RGW).
+# The backend's S3 storage backend is fully endpoint-configurable, so no code
+# change is needed. To use it, create an ObjectBucketClaim, then uncomment and
+# fill in the following (credentials come from the OBC's generated Secret):
+#
+# backend:
+#   env:
+#     STORAGE_BACKEND: "s3"
+#     S3_ENDPOINT: "https://s3.openshift-storage.svc"   # in-cluster NooBaa svc
+#     S3_BUCKET: "<obc-bucket-name>"
+#     S3_REGION: "us-east-1"
+#   # S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY: wire from the OBC Secret.
+
+# --- Arbitrary-UID security contexts -----------------------------------------
+# runAsUser/fsGroup set to null so restricted-v2 assigns them; runAsNonRoot
+# (from base values) stays, which the SCC also requires.
+backend:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+web:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+edge:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+trivy:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+scannerAdapter:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+
+dependencyTrack:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+  bootstrap:
+    podSecurityContext:
+      runAsUser: null
+      fsGroup: null
+
+opensearch:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null
+  # The opensearchproject image is arbitrary-UID friendly; the root chown init
+  # is both unnecessary and disallowed under restricted-v2 (it runs as UID 0).
+  # Disabling it lets the platform-assigned fsGroup own the data volume instead.
+  fixOwnership:
+    enabled: false
+
+fleet:
+  externalDatabaseBootstrap:
+    # Non-empty map with no runAsUser/fsGroup overrides the template default of
+    # uid/gid 70 so the SCC assigns a UID. The client tools only write to /tmp.
+    podSecurityContext:
+      runAsNonRoot: true
+
+# --- Bundled stateful services: read before enabling on a strict cluster -----
+# postgres:16-alpine (the docker-official image) runs initdb as a fixed UID and
+# will NOT come up under a fully random restricted-v2 UID: initdb refuses a data
+# directory it does not own. Choose one before deploying:
+#   (a) RECOMMENDED: use an external/managed PostgreSQL and set postgres.enabled
+#       false with the externalDatabase.* values (or a Postgres operator such as
+#       CloudNativePG / Crunchy).
+#   (b) Swap postgres.image for a UID-agnostic image (e.g. Red Hat
+#       rhel9/postgresql-16); note its data path and env vars differ from the
+#       docker-official image, so the statefulset template needs matching edits.
+#   (c) Grant the postgres ServiceAccount a UID-pinning SCC (nonroot-v2/anyuid).
+# The null overrides below are correct for options (b) and (c); they are inert
+# under (a) because the bundled postgres is not deployed.
+postgres:
+  podSecurityContext:
+    runAsUser: null
+    fsGroup: null

--- a/charts/artifact-keeper/values.yaml
+++ b/charts/artifact-keeper/values.yaml
@@ -953,6 +953,36 @@ ingress:
     enabled: true
     secretName: artifact-keeper-tls
 
+# -- OpenShift Route configuration
+# Alternative to ingress for OpenShift clusters, whose HAProxy router serves
+# Route objects rather than a Kubernetes Ingress controller. Disabled by
+# default; the OpenShift values overlay (values-openshift.yaml) turns it on and
+# turns ingress off. Do not enable both route and ingress for the same host.
+route:
+  enabled: false
+  # -- External hostname for every Route. Empty falls back to ingress.host
+  # (or fleet.host in fleet mode). Leave empty to let the OpenShift router
+  # assign a generated <name>-<namespace>.<apps-domain> hostname per Route.
+  host: ""
+  # -- Extra annotations applied to every Route (e.g. router timeouts:
+  # haproxy.router.openshift.io/timeout: 300s).
+  annotations: {}
+  tls:
+    # -- Serve the Routes over TLS. edge termination uses the router's default
+    # certificate unless you supply your own via annotations/secret.
+    enabled: true
+    # -- edge | passthrough | reencrypt. edge terminates TLS at the router and
+    # forwards plain HTTP to the services, which matches the in-cluster
+    # ClusterIP services this chart creates.
+    termination: edge
+    # -- What to do with plain-HTTP requests. Redirect sends them to HTTPS.
+    insecureEdgeTerminationPolicy: Redirect
+  dtrack:
+    # -- Publish a /dtrack Route to the bundled Dependency-Track service.
+    # Mirrors ingress.dtrack.enabled; only has effect when
+    # dependencyTrack.enabled is true.
+    enabled: false
+
 # -- Secrets
 # These are development defaults. For production, override via --set or
 # use existingSecret references. Never commit real credentials here.
@@ -1155,6 +1185,12 @@ fleet:
     # -- Name of an existing Secret holding superuser credentials for the shared
     # server, used only by the bootstrap Job. Expected keys: username, password.
     adminSecret: ""
+    # -- Pod securityContext for the bootstrap Job. Empty ({}) keeps the chart
+    # default of runAsUser/fsGroup 70 (the postgres image's uid) for plain
+    # Kubernetes. On OpenShift, set this to omit runAsUser/fsGroup so the
+    # restricted-v2 SCC can assign an arbitrary UID (the OpenShift overlay does
+    # this). The client tools only write to HOME=/tmp, so any UID works.
+    podSecurityContext: {}
   # -- Per-namespace guardrails. Each toggle is independent and off by default.
   # ResourceQuota and LimitRange are sized from the preset; the NetworkPolicy
   # restricts ingress to the named ingress-controller namespace and egress to


### PR DESCRIPTION
## Summary

First-class OpenShift compatibility for the chart, part of the OpenShift collaboration effort with Red Hat.

OpenShift's default `restricted-v2` SCC assigns a random UID (member of GID 0) and its HAProxy router serves `Route` objects rather than a Kubernetes Ingress. This PR adds both.

**Routes** (`route.yaml`, behind `route.enabled`): a Route targets a single Service, so the single-host/many-paths Ingress becomes one Route per backend path prefix (every native-format path plus `/api`, `/v2`, `/health`, `/ready`), a `/` web catch-all, and an optional `/dtrack`. The router's longest-prefix matching makes the specific backend paths win over the catch-all.

**Shared path list** (`_helpers.tpl`): the native-format path list is factored into `backendFormatPaths`, consumed by both the Ingress and the Routes so they cannot drift. The Ingress output is unchanged (verified: still 34 Prefix paths). A reusable `routeObject` helper keeps `route.yaml` DRY.

**`values-openshift.yaml` overlay**: Routes on / Ingress off; nulls every hardcoded `runAsUser`/`fsGroup` so the SCC assigns UIDs; disables the OpenSearch root chown init (relying on the platform-assigned fsGroup); documents pointing the S3 backend at OpenShift Data Foundation / NooBaa. It is explicit about the one real limitation: bundled `postgres:16-alpine` will not initdb under a fully random UID (Phase 2: swap to a Red Hat UBI Postgres image).

**Fleet bootstrap Job**: the hardcoded UID 70 is now values-driven via a backward-compatible `with/else`, so the overlay can blank it.

**CI**: adds an `openshift` variant to the render/validate matrix.

Closes #309

## Test Checklist
- [x] Helm template renders without errors
- [ ] Terraform validates/plans cleanly
- [ ] Manually verified on staging cluster (if applicable)
- [x] Rollback strategy documented

## Infrastructure
- [x] Helm: `helm template` renders correctly
- [ ] Terraform: `terraform validate` passes
- [ ] Terraform: `terraform plan` shows expected changes
- [ ] ArgoCD: Application manifests are valid
- [x] N/A - documentation only

<sub>Verified locally: `helm lint` clean; default overlay renders 34 Ingress Prefix paths (unchanged) and 0 Routes; OpenShift overlay renders 36 Routes, 0 Ingress, and 0 `runAsUser`.</sub>