### PR TITLE
ci(release): publish the chart to ghcr.io as an OCI artifact

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -79,6 +79,8 @@ jobs:
     runs-on: ak-ci-runners
     permissions:
       contents: write
+      # Pushing the chart to ghcr.io as an OCI artifact.
+      packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -100,3 +102,28 @@ jobs:
           config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Second, independent distribution channel for the same chart version. The Pages index is a
+      # single point of failure: when its deployment fails the release asset exists and no documented
+      # path can reach it, because a stale index and a current one both answer 200. An OCI reference
+      # also resolves to a digest, which is what lets a consumer pin the chart the way the images are
+      # already pinned.
+      - name: Push chart to ghcr.io as an OCI artifact
+        run: |
+          set -euo pipefail
+          version=$(grep '^version:' charts/artifact-keeper/Chart.yaml | awk '{print $2}')
+          helm package charts/artifact-keeper --destination "$RUNNER_TEMP/chart"
+          printf '%s' "$GHCR_TOKEN" | helm registry login ghcr.io \
+            --username "$GITHUB_ACTOR" --password-stdin
+          helm push \
+            "$RUNNER_TEMP/chart/artifact-keeper-${version}.tgz" \
+            "oci://ghcr.io/${{ github.repository_owner }}/charts"
+          # The push is not the assertion: a tag that failed to publish and one that published are both
+          # silent here, so pull the version back by name before calling the release distributed.
+          helm show chart "oci://ghcr.io/${{ github.repository_owner }}/charts/artifact-keeper" \
+            --version "$version" > /dev/null
+          echo "chart $version is resolvable at oci://ghcr.io/${{ github.repository_owner }}/charts/artifact-keeper"
+        env:
+          # Passed as an environment variable rather than interpolated into the script body, so the
+          # token never becomes part of the shell command line.
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Publishes each released chart version to `ghcr.io` as an OCI artifact, in the same release job, alongside the existing Pages index.

Today the Pages index is the only way to reach a released chart, which makes it a single point of failure — and the failure is silent, because a stale index and a current one both answer 200. That is live on 1.9.8 right now (#312): the tgz is attached to its release and committed to `gh-pages`, while the served index still advertises 1.9.7, so `helm repo add` + `helm dependency update` cannot resolve the current chart at all.

The registry, the credentials and the org are already in use — `artifact-keeper-backend`, `artifact-keeper-web` and `artifact-keeper-scanner-adapter` all publish to `ghcr.io/artifact-keeper/*`. Only the chart is absent.

## What changed

`.github/workflows/helm-release.yml`, one step and one permission on the existing `release` job:

- `permissions: packages: write`
- a `Push chart to ghcr.io as an OCI artifact` step after `chart-releaser`, reusing the version the job already derives from `Chart.yaml`

After this, both of these resolve the same version:

```
helm repo add ak https://artifact-keeper.github.io/artifact-keeper-iac/
helm install ak oci://ghcr.io/artifact-keeper/charts/artifact-keeper --version 1.9.8
```

`dependencies.repository` accepts an `oci://` URL, so a consumer chart can pin the upstream chart without depending on an index being regenerated.

## Notes for review

- **The push is not the assertion.** `helm push` says nothing about whether the version became resolvable, so the step pulls the chart metadata back by version (`helm show chart oci://... --version "$version"`) before reporting success. Without that, a release that failed to publish and one that published look identical in the log.
- **The token is passed as an environment variable**, not interpolated into the script body, so it never becomes part of the shell command line.
- **Idempotency.** The step runs under the job's existing `if: needs.version-check.outputs.changed == 'true'`, so it only fires for a version that has no tag yet — matching `skip_existing: "true"` on chart-releaser.
- `$RUNNER_TEMP` is used for the package output rather than the workspace, so nothing lands in the checkout that a later step could pick up.

## Testing

I cannot run this repository's CI, so what I verified locally against `charts/artifact-keeper` at 1.9.8:

- the version expression yields `1.9.8`
- `helm package charts/artifact-keeper --destination <dir>` produces exactly `artifact-keeper-1.9.8.tgz`, the filename the push step references
- the workflow file still parses as YAML, and the `release` job's steps and permissions are as intended

The `helm registry login` / `helm push` / `helm show chart` sequence is untested by me, since it needs `packages: write` in this org. Worth a maintainer eye on the first run — in particular whether `ak-ci-runners` reaches `ghcr.io` outbound.

Closes #314
